### PR TITLE
FIX: allow non-locations tests to continue even if locations CF is not defined (again)

### DIFF
--- a/assets/javascripts/discourse/initializers/location-edits.js
+++ b/assets/javascripts/discourse/initializers/location-edits.js
@@ -243,7 +243,7 @@ export default {
         if (
           typeof category !== "undefined" &&
           category &&
-          category.custom_fields.location_enabled &&
+          category.custom_fields?.location_enabled &&
           category.siteSettings.location_category_map_filter
         ) {
           items.push(NavItem.fromText("map", args)); // Show category level "/map" instead

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 6.8.2
+# version: 6.8.3
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations


### PR DESCRIPTION
Sorry, it seems I missed an occurrence. It should be the last.