### PR TITLE
FIX: post update to create TopicLocation

### DIFF
--- a/lib/locations/topic_location_process.rb
+++ b/lib/locations/topic_location_process.rb
@@ -3,15 +3,13 @@
 module ::Locations
   class TopicLocationProcess
 
-    def self.upsert(topic_id)
-      topic = Topic.find_by(id: topic_id)
-
+    def self.upsert(topic)
       return if topic.nil? || !topic.custom_fields['location'].present? ||
         topic.custom_fields['location']['geo_location'].blank? || !topic.custom_fields['location']['geo_location']['lat'].present? ||
         !topic.custom_fields['location']['geo_location']['lon'].present?
 
       ::Locations::TopicLocation.upsert({
-          topic_id: topic_id,
+          topic_id: topic.id,
           latitude: topic.custom_fields['location']['geo_location']['lat'],
           longitude: topic.custom_fields['location']['geo_location']['lon'],
           name: topic.custom_fields['location']['name'] || nil,

--- a/lib/tasks/locations.rake
+++ b/lib/tasks/locations.rake
@@ -86,7 +86,7 @@ def refresh_topic_location_table(args)
         .limit(batch)
         .each do |topic|
           if !missing_only.to_i.zero? && ::Locations::TopicLocation.find_by(topic_id: topic.id).nil? || missing_only.to_i.zero?
-            Locations::TopicLocationProcess.upsert(topic.id)
+            Locations::TopicLocationProcess.upsert(topic)
             sleep(delay) if delay
           end
           print_status(refreshed += 1, total)

--- a/plugin.rb
+++ b/plugin.rb
@@ -152,7 +152,7 @@ after_initialize do
       tc.topic.custom_fields['location'] = location
       tc.topic.custom_fields['has_geo_location'] = location['geo_location'].present?
 
-      Locations::TopicLocationProcess.upsert(tc.topic.id)
+      Locations::TopicLocationProcess.upsert(tc.topic)
     else
       tc.topic.custom_fields['location'] = {}
       tc.topic.custom_fields['has_geo_location'] = false
@@ -168,7 +168,7 @@ after_initialize do
       topic.custom_fields['location'] = location
       topic.custom_fields['has_geo_location'] = location['geo_location'].present?
       topic.save!
-      Locations::TopicLocationProcess.upsert(topic.id)
+      Locations::TopicLocationProcess.upsert(topic)
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 6.8.7
+# version: 6.8.8
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/spec/requests/topic_controller_location_update_spec.rb
+++ b/spec/requests/topic_controller_location_update_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe TopicsController do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:category) { Fabricate(:category, custom_fields: { location_enabled: true }) }
+
+  before do
+    sign_in(user)
+    SiteSetting.location_enabled = true
+  end
+
+  describe "#create" do
+    it "should create topic with custom fields and create TopicLocation" do
+      post "/posts.json",
+           params: {
+             raw: "this is the test content",
+             title: "this is the test title for the topic",
+             category: category.id,
+             location: {
+               geo_location: {
+                 lat: 10,
+                 lon: 12,
+               },
+             },
+           }
+      expect(response.status).to eq(200)
+
+      result = response.parsed_body
+      topic = Topic.find(result["topic_id"])
+
+      expect(topic.custom_fields).to eq(
+        {
+          "has_geo_location" => true,
+          "location" => {
+            "geo_location" => {
+              "lat" => "10",
+              "lon" => "12",
+            },
+          },
+        },
+      )
+      expect(::Locations::TopicLocation.find_by(topic: topic)).to be_present
+    end
+  end
+
+  describe "#update" do
+    fab!(:topic) { Fabricate(:topic, user: user) }
+    fab!(:post) { Fabricate(:post, user: user, topic: topic) }
+
+    it "should update topic with custom fields and create TopicLocation" do
+      put "/t/#{topic.id}.json", params: { location: { geo_location: { lat: 10, lon: 12 } } }
+
+      expect(response.status).to eq(200)
+
+      topic.reload
+      expect(topic.custom_fields).to eq(
+        {
+          "has_geo_location" => true,
+          "location" => {
+            "geo_location" => {
+              "lat" => "10",
+              "lon" => "12",
+            },
+          },
+        },
+      )
+      expect(::Locations::TopicLocation.find_by(topic: topic)).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Added a test to confirm the problem and fix.

`upsert` was re-finding the topic before the changes were saved, so the custom_fields were missing and TopicLocation not created. It was working on create because it uses the post_created event which happens after its persisted.

This change simply passes the topic object to upsert instead of re-finding.

