### PR TITLE
FIX: use Discovery::Layout

### DIFF
--- a/assets/javascripts/discourse/templates/discovery/map.hbs
+++ b/assets/javascripts/discourse/templates/discovery/map.hbs
@@ -1,17 +1,27 @@
-<Discovery::Navigation
-  @category={{this.model.category}}
-  @tag={{this.model.tag}}
-  @additionalTags={{this.additionalTags}}
-  @filterType={{this.model.filterType}}
-  @noSubcategories={{this.model.noSubcategories}}
-  @canBulkSelect={{this.canBulkSelect}}
-  @bulkSelectHelper={{this.bulkSelectHelper}}
-  @createTopic={{this.createTopic}}
+<Discovery::Layout
+  @model={{this.model}}
   @createTopicDisabled={{this.createTopicDisabled}}
-  @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
-  @toggleTagInfo={{this.toggleTagInfo}}
-  @tagNotification={{this.tagNotification}}
-/>
-<div class="map-component map-container">
-  <LocationsMap @mapType="topicList" />
-</div>
+>
+  <:navigation>
+    <Discovery::Navigation
+      @category={{this.model.category}}
+      @tag={{this.model.tag}}
+      @additionalTags={{this.additionalTags}}
+      @filterType={{this.model.filterType}}
+      @noSubcategories={{this.model.noSubcategories}}
+      @canBulkSelect={{this.canBulkSelect}}
+      @bulkSelectHelper={{this.bulkSelectHelper}}
+      @createTopic={{this.createTopic}}
+      @createTopicDisabled={{this.createTopicDisabled}}
+      @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
+      @toggleTagInfo={{this.toggleTagInfo}}
+      @tagNotification={{this.tagNotification}}
+    />
+  </:navigation>
+
+  <:list>
+    <div class="map-component map-container">
+      <LocationsMap @mapType="topicList" />
+    </div>
+  </:list>
+</Discovery::Layout>

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 6.8.8
+# version: 6.8.9
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations


### PR DESCRIPTION
Seeing style issues with a theme on the maps page that doesn't match the other "discovery" pages due to different markup.

So I tried to incorporate the Layout wrapper [as seen here in list.gjs](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/templates/discovery/list.gjs) which resolved the issue.
