### PR TITLE
IMPROVE: align User Map permissions with User Directory permissions

### DIFF
--- a/assets/javascripts/discourse/initializers/location-map-edits.js
+++ b/assets/javascripts/discourse/initializers/location-map-edits.js
@@ -9,6 +9,7 @@ export default {
   initialize(container) {
     withPluginApi("0.8.12", (api) => {
       const siteSettings = container.lookup("site-settings:main");
+      const currentUser = container.lookup("service:current-user");
 
       if (siteSettings.location_sidebar_menu_map_link) {
         api.addCommunitySectionLink({
@@ -19,7 +20,11 @@ export default {
         });
       }
 
-      if (siteSettings.location_users_map) {
+      if (
+        siteSettings.location_users_map &&
+        siteSettings.enable_user_directory &&
+        !(!currentUser && siteSettings.hide_user_profiles_from_public)
+      ) {
         api.addCommunitySectionLink({
           name: "users map",
           route: "locations.users-map",

--- a/lib/users_map.rb
+++ b/lib/users_map.rb
@@ -3,6 +3,8 @@ module DirectoryItemsControllerExtension
   def index
     if params[:period] === 'location'
       raise Discourse::InvalidAccess.new(:enable_user_directory) unless SiteSetting.enable_user_directory?
+      raise Discourse::InvalidAccess.new(:location_users_map) unless SiteSetting.location_users_map?
+      raise Discourse::InvalidAccess.new(:hide_user_profiles_from_public) if SiteSetting.hide_user_profiles_from_public? && !current_user
 
       limit = SiteSetting.location_users_map_limit.to_i
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 6.8.10
+# version: 6.8.11
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/plugin.rb
+++ b/plugin.rb
@@ -141,7 +141,7 @@ after_initialize do
   end
 
   public_user_custom_fields = SiteSetting.public_user_custom_fields.split('|')
-  public_user_custom_fields.push('geo_location') unless public_user_custom_fields.include?('geo_location')
+  public_user_custom_fields.push('geo_location') if public_user_custom_fields.exclude?('geo_location')
   SiteSetting.public_user_custom_fields = public_user_custom_fields.join('|')
 
   PostRevisor.track_topic_field(:location) do |tc, location|

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe DirectoryItemsController do
       expect(response.status).to eq(403)
       expect(response.parsed_body["error_type"]).to eq("invalid_access")
     end
+    it "doesn't allow user to browse the users map when user map is disabled" do
+      SiteSetting.location_users_map = false
+      SiteSetting.enable_user_directory = true
+      get "/directory_items.json?period=location"
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["error_type"]).to eq("invalid_access")
+    end
   end
   context "when the plugin is enabled but the user is not logged in" do
     before do

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DirectoryItemsController do
+  fab!(:user)
+
+  context "browsing the users map" do
+    before(:each) do
+      SiteSetting.location_enabled = true
+      sign_in(user)
+    end
+    it "allows user to browse the users map" do
+      SiteSetting.location_users_map = true
+      SiteSetting.enable_user_directory = true
+      get "/directory_items.json?period=location"
+      expect(response.status).to eq(200)
+    end
+    it "doesn't allow user to browse the users map when user directory is disabled" do
+      SiteSetting.location_users_map = true
+      SiteSetting.enable_user_directory = false
+      get "/directory_items.json?period=location"
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["error_type"]).to eq("invalid_access")
+    end
+  end
+  context "when the plugin is enabled but the user is not logged in" do
+    before do
+      SiteSetting.location_users_map = true
+      SiteSetting.enable_user_directory = true
+      SiteSetting.hide_user_profiles_from_public = true
+    end
+    it "doesn't allow user to browse the users map when the plugin is enabled but the user is not logged in" do
+      sign_out
+      get "/directory_items.json?period=location"
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["error_type"]).to eq("invalid_access")
+    end
+  end
+end

--- a/spec/requests/user_controller_location_update_spec.rb
+++ b/spec/requests/user_controller_location_update_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe UsersController do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user)
   user_field = Fabricate(:user_field, editable: true)
   before do
     sign_in(user)


### PR DESCRIPTION
User Map will no longer serve data if:

* User is not logged in and `hide_user_profiles_from_public` is active.
* Plugin setting `location_user_map` is OFF
* Site's `enable_user_directory` is OFF

User Map link in community section should no longer show in those circumstances either.