### PR TITLE
FIX: undefined title in locations-topic-map-modal

### DIFF
--- a/assets/javascripts/discourse/components/modal/locations-topic-map-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/locations-topic-map-modal.gjs
@@ -6,7 +6,7 @@ import LocationsMap from "./../locations-map";
 export default class LocationsTopicMapModalComponent extends Component {
   get title() {
     return i18n("map.topic_modal.label", {
-      topic_title: this.model.topic.title,
+      topic_title: this.args.model.topic.title,
     });
   }
 


### PR DESCRIPTION
Use this.args.model instead of this.model to fix an undefined topic error in the locations map modal
