### PR TITLE
FIX: IP lookup logging autoload

### DIFF
--- a/app/jobs/regular/locations/ip_location_lookup.rb
+++ b/app/jobs/regular/locations/ip_location_lookup.rb
@@ -12,7 +12,7 @@ module ::Jobs
         return if ENV["DISCOURSE_MAXMIND_ACCOUNT_ID"].blank?
         return if ENV["DISCOURSE_MAXMIND_LICENSE_KEY"].blank?
 
-        ::Locations.ip_lookup_log(
+        ::Locations::LoggingHelper.ip_lookup_log(
           "1. Locations IP lookup start: user_id=#{args[:user_id]} ip_address=#{args[:ip_address]}",
         )
 
@@ -27,7 +27,7 @@ module ::Jobs
         return if ::Locations::IpLocationLookup.should_skip_existing_location?(user)
 
         ip_info = DiscourseIpInfo.get(ip_address)
-        ::Locations.ip_lookup_log(
+        ::Locations::LoggingHelper.ip_lookup_log(
           "2. Locations IP lookup MaxMind response: user_id=#{user_id} ip_address=#{ip_address} ip_info=#{ip_info.inspect}",
         )
         return if ip_info.blank?
@@ -37,12 +37,12 @@ module ::Jobs
             ip_info,
             granularity: SiteSetting.location_ip_granularity,
           )
-        ::Locations.ip_lookup_log(
+        ::Locations::LoggingHelper.ip_lookup_log(
           "7. Locations IP lookup GeoLocationBuilder result: user_id=#{user_id} ip_address=#{ip_address} geo_location=#{geo_location.inspect}",
         )
 
         if geo_location.blank?
-          ::Locations.ip_lookup_log(
+          ::Locations::LoggingHelper.ip_lookup_log(
             "7. Locations IP lookup: no geo_location built for user_id=#{user_id} ip_address=#{ip_address}",
           )
           return
@@ -51,11 +51,11 @@ module ::Jobs
         user.custom_fields["geo_location"] = geo_location.to_json
         ::Locations::IpLocationLookup.mark_lookup!(user)
         user.save_custom_fields(true)
-        ::Locations.ip_lookup_log(
+        ::Locations::LoggingHelper.ip_lookup_log(
           "8. Locations IP lookup saved geo_location: user_id=#{user_id} ip_address=#{ip_address}",
         )
         ::Locations::UserLocationProcess.upsert(user.id)
-        ::Locations.ip_lookup_log(
+        ::Locations::LoggingHelper.ip_lookup_log(
           "9. Locations IP lookup updated user_location: user_id=#{user_id} ip_address=#{ip_address}",
         )
       end

--- a/lib/locations/geo_location_builder.rb
+++ b/lib/locations/geo_location_builder.rb
@@ -3,7 +3,7 @@
 module ::Locations
   class GeoLocationBuilder
     def self.from_ip_info(ip_info, granularity:)
-      ::Locations.ip_lookup_log(
+      ::Locations::LoggingHelper.ip_lookup_log(
         "3. Locations GeoLocationBuilder: granularity=#{granularity} ip_info=#{ip_info.inspect}",
       )
       ids = ip_info[:geoname_ids] || ip_info["geoname_ids"]
@@ -47,6 +47,5 @@ module ::Locations
         "id" => "geoname:#{chosen[:geoname_id]}",
       }
     end
-
   end
 end

--- a/lib/locations/geo_names_client.rb
+++ b/lib/locations/geo_names_client.rb
@@ -8,8 +8,8 @@ module ::Locations
     def initialize
       @base_url = DEFAULT_BASE_URL
       @username = SiteSetting.location_geonames_username
-      ::Locations.ip_lookup_log("5. Locations GeoNamesClient initialized")
-      ::Locations.ip_lookup_log("5. Locations GeoNamesClient base_url=#{@base_url}")
+      ::Locations::LoggingHelper.ip_lookup_log("5. Locations GeoNamesClient initialized")
+      ::Locations::LoggingHelper.ip_lookup_log("5. Locations GeoNamesClient base_url=#{@base_url}")
     end
 
     def get_feature(geoname_id)
@@ -31,14 +31,16 @@ module ::Locations
     end
 
     def fetch_and_normalize(id)
-      ::Locations.ip_lookup_log("5. Locations GeoNames fetch: geoname_id=#{id}")
+      ::Locations::LoggingHelper.ip_lookup_log("5. Locations GeoNames fetch: geoname_id=#{id}")
       url =
         "#{@base_url}getJSON?" +
           URI.encode_www_form(geonameId: id, username: @username, style: "full", formatted: "true")
 
-      ::Locations.ip_lookup_log("5. Locations GeoNames request: url=#{url}")
+      ::Locations::LoggingHelper.ip_lookup_log("5. Locations GeoNames request: url=#{url}")
       body = FinalDestination::HTTP.get(URI(url))
-      ::Locations.ip_lookup_log("5. Locations GeoNames response: geoname_id=#{id} body=#{body}")
+      ::Locations::LoggingHelper.ip_lookup_log(
+        "5. Locations GeoNames response: geoname_id=#{id} body=#{body}",
+      )
       raw = JSON.parse(body)
       return nil if raw["status"]
 
@@ -53,12 +55,12 @@ module ::Locations
         country_name: raw["countryName"],
         admin1: raw["adminName1"],
       }
-      ::Locations.ip_lookup_log(
+      ::Locations::LoggingHelper.ip_lookup_log(
         "5. Locations GeoNames feature: geoname_id=#{feature[:geoname_id]} name=#{feature[:name]} lat=#{feature[:lat]} lon=#{feature[:lon]} fcl=#{feature[:fcl]} fcode=#{feature[:fcode]}",
       )
       feature
     rescue StandardError => e
-      ::Locations.ip_lookup_log("5. GeoNames lookup failed (#{id}): #{e.message}")
+      ::Locations::LoggingHelper.ip_lookup_log("5. GeoNames lookup failed (#{id}): #{e.message}")
       nil
     end
   end

--- a/lib/locations/geo_names_granularity_picker.rb
+++ b/lib/locations/geo_names_granularity_picker.rb
@@ -5,7 +5,9 @@ module ::Locations
     CITY_PRIORITY = { "PPLC" => 5, "PPLA" => 4, "PPLA2" => 3, "PPLA3" => 2, "PPL" => 1 }.freeze
 
     def self.pick(ids, granularity:)
-      ::Locations.ip_lookup_log("4. Locations GeoNames pick: ids=#{ids.inspect} granularity=#{granularity}")
+      ::Locations::LoggingHelper.ip_lookup_log(
+        "4. Locations GeoNames pick: ids=#{ids.inspect} granularity=#{granularity}",
+      )
       client = GeoNamesClient.new
       features = Array(ids).uniq.filter_map { |id| client.get_feature(id) }
 
@@ -17,7 +19,7 @@ module ::Locations
           .select { |f| f[:fcl] == "P" && f[:fcode].start_with?("PPL") }
           .max_by { |f| CITY_PRIORITY.fetch(f[:fcode], 0) }
 
-      ::Locations.ip_lookup_log(
+      ::Locations::LoggingHelper.ip_lookup_log(
         "6. Locations GeoNames pick result: country=#{country&.dig(:geoname_id)} admin1=#{admin1&.dig(:geoname_id)} admin2=#{admin2&.dig(:geoname_id)} city=#{city&.dig(:geoname_id)}",
       )
 

--- a/lib/locations/logging_helper.rb
+++ b/lib/locations/logging_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module ::Locations
-  def self.ip_lookup_log(message)
-    return unless SiteSetting.location_ip_lookup_debug_logging
+  module LoggingHelper
+    def self.ip_lookup_log(message)
+      return unless SiteSetting.location_ip_lookup_debug_logging
 
-    Rails.logger.warn(message)
+      Rails.logger.warn(message)
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.1.9
+# version: 7.1.10
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.1.8
+# version: 7.1.9
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/spec/lib/locations/logging_helper_spec.rb
+++ b/spec/lib/locations/logging_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe ::Locations::LoggingHelper do
+  describe ".ip_lookup_log" do
+    it "logs when debug logging is enabled" do
+      SiteSetting.location_ip_lookup_debug_logging = true
+
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.ip_lookup_log("hello")
+
+      expect(Rails.logger).to have_received(:warn).with("hello")
+    end
+
+    it "does not log when debug logging is disabled" do
+      SiteSetting.location_ip_lookup_debug_logging = false
+
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.ip_lookup_log("hello")
+
+      expect(Rails.logger).not_to have_received(:warn)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  This fixes the IP lookup logging helper so Sidekiq jobs and related lookup classes can resolve it reliably under Zeitwerk autoloading.

  The previous implementation added `ip_lookup_log` by reopening `Locations` directly, which is not a stable autoload target. In some runtime paths,
  especially background jobs, that method could be missing and IP lookup would fail when logging was invoked.

  ## Changes

  - move IP lookup logging behind an autoloadable constant: `Locations::LoggingHelper.ip_lookup_log`
  - update all IP lookup / GeoNames call sites to use `Locations::LoggingHelper`
  - add spec coverage for logging enabled and disabled behavior

  ## Files Changed

  - `app/jobs/regular/locations/ip_location_lookup.rb`
  - `lib/locations/geo_location_builder.rb`
  - `lib/locations/geo_names_client.rb`
  - `lib/locations/geo_names_granularity_picker.rb`
  - `lib/locations/logging_helper.rb`
  - `spec/lib/locations/logging_helper_spec.rb`

  ## Verification

  - `bin/rspec plugins/discourse-locations/spec/lib/locations/logging_helper_spec.rb`