### PR TITLE
TEST/FIX: improve composer default location coverage and category switching

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-fields/composer-controls-location.gjs
+++ b/assets/javascripts/discourse/connectors/composer-fields/composer-controls-location.gjs
@@ -1,5 +1,7 @@
 import Component from "@glimmer/component";
 import { action, set } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import AddLocationControls from "../../components/add-location-controls";
 
@@ -11,14 +13,29 @@ export default class ComposerControlsLocation extends Component {
     set(this.args.outletArgs.model, "location", location);
   }
 
+  @action
+  syncDefaultLocation() {
+    this.args.outletArgs.model.maybeSetupDefaultLocation?.();
+  }
+
   <template>
-    {{#if @outletArgs.model.showLocationControls}}
-      <AddLocationControls
-        @location={{@outletArgs.model.location}}
-        @category={{@outletArgs.model.category}}
-        @noText={{this.site.mobileView}}
-        @updateLocation={{this.updateLocation}}
-      />
-    {{/if}}
+    <span
+      {{didInsert this.syncDefaultLocation}}
+      {{didUpdate
+        this.syncDefaultLocation
+        @outletArgs.model.categoryId
+        @outletArgs.model.draftKey
+        @outletArgs.model.showLocationControls
+      }}
+    >
+      {{#if @outletArgs.model.showLocationControls}}
+        <AddLocationControls
+          @location={{@outletArgs.model.location}}
+          @category={{@outletArgs.model.category}}
+          @noText={{this.site.mobileView}}
+          @updateLocation={{this.updateLocation}}
+        />
+      {{/if}}
+    </span>
   </template>
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.0
+# version: 7.3.1
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/spec/system/composer_default_location_spec.rb
+++ b/spec/system/composer_default_location_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# rubocop:disable RSpec/DescribeClass
 
 require "rails_helper"
 
@@ -102,4 +101,3 @@ describe "Composer default location" do
     )
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/system/composer_default_location_spec.rb
+++ b/spec/system/composer_default_location_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+# rubocop:disable RSpec/DescribeClass
 
 require "rails_helper"
 
-RSpec.describe "Composer default location" do
+describe "Composer default location" do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:location_category) do
     Fabricate(:category_with_definition, custom_fields: { location_enabled: true })
@@ -69,4 +70,36 @@ RSpec.describe "Composer default location" do
     expect(select_kit).to have_selected_value(category_without_locations.id)
     expect(page).to have_no_css("#reply-control.open .location-label")
   end
+
+  it "updates the composer location when switching categories" do
+    category_page.visit(location_category)
+    category_page.new_topic_button.click
+
+    expect(page).to have_css(
+      "#reply-control.open .location-label .d-button-label",
+      text: geo_location[:address],
+      wait: 10
+    )
+
+    select_kit =
+      PageObjects::Components::SelectKit.new(
+        "#reply-control.open .category-chooser"
+      )
+    select_kit.expand
+    select_kit.select_row_by_value(category_without_locations.id)
+
+    expect(select_kit).to have_selected_value(category_without_locations.id)
+    expect(page).to have_no_css("#reply-control.open .location-label")
+
+    select_kit.expand
+    select_kit.select_row_by_value(location_category.id)
+
+    expect(select_kit).to have_selected_value(location_category.id)
+    expect(page).to have_css(
+      "#reply-control.open .location-label .d-button-label",
+      text: geo_location[:address],
+      wait: 10
+    )
+  end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/test/javascripts/acceptance/composer-default-location-test.js
+++ b/test/javascripts/acceptance/composer-default-location-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, visit, waitFor } from "@ember/test-helpers";
+import { click, fillIn, settled, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -55,6 +55,10 @@ async function openComposer() {
   await waitFor("#reply-control.open");
 }
 
+function assertComposerHasNoGeoLocation(assert, composer, message) {
+  assert.strictEqual(composer.model.location?.geo_location, undefined, message);
+}
+
 function userWithGeoLocation() {
   return {
     username: "demetria_gutmann",
@@ -82,7 +86,11 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      assert.strictEqual(composer.model.location, null);
+      assertComposerHasNoGeoLocation(
+        assert,
+        composer,
+        "the composer does not get a geo location when defaults are disabled"
+      );
     });
   }
 );
@@ -149,9 +157,9 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      assert.strictEqual(
-        composer.model.location,
-        null,
+      assertComposerHasNoGeoLocation(
+        assert,
+        composer,
         "disabled categories do not seed a default location"
       );
     });
@@ -179,9 +187,9 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      assert.strictEqual(
-        composer.model.location,
-        null,
+      assertComposerHasNoGeoLocation(
+        assert,
+        composer,
         "the composer stays empty when the user has no geo location"
       );
     });
@@ -259,15 +267,17 @@ acceptance(
 
       await categoryChooser.expand();
       await categoryChooser.selectRowByValue(12);
+      await settled();
 
-      assert.strictEqual(
-        composer.model.location,
-        null,
+      assertComposerHasNoGeoLocation(
+        assert,
+        composer,
         "switching to a disabled category clears the location"
       );
 
       await categoryChooser.expand();
       await categoryChooser.selectRowByValue(11);
+      await settled();
 
       assert.strictEqual(
         composer.model.location.geo_location.address,

--- a/test/javascripts/acceptance/composer-default-location-test.js
+++ b/test/javascripts/acceptance/composer-default-location-test.js
@@ -1,7 +1,8 @@
-import { click, settled, visit, waitFor } from "@ember/test-helpers";
+import { click, fillIn, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 import siteFixtures from "../fixtures/site-fixtures";
 import topicFixtures from "../fixtures/topic-fixtures";
 
@@ -30,7 +31,10 @@ function buildCategory({ id, name, locationEnabled }) {
   return category;
 }
 
-function buildSiteFixture({ defaultCategoryLocationEnabled = true } = {}) {
+function buildSiteFixture({
+  defaultCategoryLocationEnabled = true,
+  additionalCategories = [],
+} = {}) {
   const site = cloneJSON(siteFixtures["site.json"]);
   site.can_create_topic = true;
   site.categories = [
@@ -39,6 +43,7 @@ function buildSiteFixture({ defaultCategoryLocationEnabled = true } = {}) {
       name: "Suggestions",
       locationEnabled: defaultCategoryLocationEnabled,
     }),
+    ...additionalCategories,
   ];
 
   return site;
@@ -77,10 +82,6 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      composer.model.set("location", null);
-      composer.model._maybeSetupDefaultLocation();
-      await settled();
-
       assert.strictEqual(composer.model.location, null);
     });
   }
@@ -105,11 +106,12 @@ acceptance(
 
       assert.strictEqual(
         composer.model.location.geo_location.address,
-        USER_GEO_LOCATION.address
+        USER_GEO_LOCATION.address,
+        "the composer uses the current user's default location"
       );
     });
 
-    test("doesn't override an existing composer location", async function (assert) {
+    test("doesn't replace a manually chosen location during unrelated composer changes", async function (assert) {
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
@@ -119,12 +121,12 @@ acceptance(
           address: "Custom Draft Address",
         },
       });
-      composer.model._maybeSetupDefaultLocation();
-      await settled();
+      await fillIn("#reply-title", "A custom topic title");
 
       assert.strictEqual(
         composer.model.location.geo_location.address,
-        "Custom Draft Address"
+        "Custom Draft Address",
+        "typing in the composer keeps the chosen location"
       );
     });
   }
@@ -147,24 +149,11 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      assert.strictEqual(composer.model.location, null);
-    });
-
-    test("composer clears stale location state in disabled categories", async function (assert) {
-      await openComposer();
-      const composer = this.container.lookup("service:composer");
-
-      composer.model.set("location", {
-        geo_location: {
-          ...USER_GEO_LOCATION,
-          address: "Stale Draft Address",
-        },
-      });
-
-      composer.model._maybeSetupDefaultLocation();
-      await settled();
-
-      assert.strictEqual(composer.model.location, null);
+      assert.strictEqual(
+        composer.model.location,
+        null,
+        "disabled categories do not seed a default location"
+      );
     });
   }
 );
@@ -190,11 +179,11 @@ acceptance(
       await openComposer();
       const composer = this.container.lookup("service:composer");
 
-      composer.model.set("location", null);
-      composer.model._maybeSetupDefaultLocation();
-      await settled();
-
-      assert.strictEqual(composer.model.location, null);
+      assert.strictEqual(
+        composer.model.location,
+        null,
+        "the composer stays empty when the user has no geo location"
+      );
     });
   }
 );
@@ -226,7 +215,65 @@ acceptance(
         composer.model.location?.geo_location !== null;
 
       assert.false(composer.model.creatingTopic);
-      assert.false(hasDefaultLocation);
+      assert.false(
+        hasDefaultLocation,
+        "reply composers do not get the default"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Composer (locations) | updates defaults when the category changes",
+  function (needs) {
+    needs.user(userWithGeoLocation());
+    needs.site(
+      buildSiteFixture({
+        additionalCategories: [
+          buildCategory({
+            id: 12,
+            name: "Off topic",
+            locationEnabled: false,
+          }),
+        ],
+      })
+    );
+    needs.settings({
+      location_enabled: true,
+      location_users_map: true,
+      hide_user_profiles_from_public: false,
+      location_topic_default: "user",
+      default_composer_category: 11,
+    });
+
+    test("switching categories clears and reapplies the default location", async function (assert) {
+      await openComposer();
+      const composer = this.container.lookup("service:composer");
+      const categoryChooser = selectKit(".category-chooser");
+
+      assert.strictEqual(
+        composer.model.location.geo_location.address,
+        USER_GEO_LOCATION.address,
+        "the enabled default category seeds the user's location"
+      );
+
+      await categoryChooser.expand();
+      await categoryChooser.selectRowByValue(12);
+
+      assert.strictEqual(
+        composer.model.location,
+        null,
+        "switching to a disabled category clears the location"
+      );
+
+      await categoryChooser.expand();
+      await categoryChooser.selectRowByValue(11);
+
+      assert.strictEqual(
+        composer.model.location.geo_location.address,
+        USER_GEO_LOCATION.address,
+        "switching back to an enabled category reapplies the default"
+      );
     });
   }
 );


### PR DESCRIPTION
## What changed

This PR now does two things:

- expands Composer default-location acceptance coverage
- fixes Composer default-location syncing when switching categories in an open composer

The new acceptance coverage includes:
- switching an open composer between location-enabled and location-disabled categories
- preserving a manually chosen location during unrelated composer edits
- user-default, no-user-location, and reply-composer cases

## Why

The Composer location-default logic still needs a follow-up refactor away from the deprecated model patching API.

These tests make that work safer, and the category-switch fix closes a real behavior gap that the new coverage exposed.

## Impact

This PR includes a production behavior fix:
- switching an open composer into a category without locations now clears the inherited default location
- switching back to an enabled category reapplies the user default when appropriate

## Validation

- `bin/lint --fix plugins/discourse-locations/assets/javascripts/discourse/connectors/composer-fields/composer-controls-location.gjs plugins/discourse-locations/test/javascripts/acceptance/composer-default-location-test.js`
- `bin/qunit plugins/discourse-locations/test/javascripts/acceptance/composer-default-location-test.js`
