### PR TITLE
FIX: Restore location search and map safeguards

### DIFF
--- a/assets/javascripts/discourse/components/location-form.gjs
+++ b/assets/javascripts/discourse/components/location-form.gjs
@@ -37,7 +37,6 @@ export default class LocationForm extends Component {
   @tracked formCountrycode;
   @tracked formLatitude;
   @tracked formLongitude;
-  formState;
   geoLocation = {};
   context = null;
 
@@ -194,7 +193,14 @@ export default class LocationForm extends Component {
       }
     });
 
-    if (Object.keys(request).length === 0) {
+    if (
+      !Object.values(request).some(
+        (value) =>
+          value !== undefined &&
+          value !== null &&
+          String(value).trim().length > 0
+      )
+    ) {
       return;
     }
 

--- a/assets/javascripts/discourse/components/location-selector.gjs
+++ b/assets/javascripts/discourse/components/location-selector.gjs
@@ -91,9 +91,7 @@ export default class LocationSelector extends Component {
 
       return locations;
     } catch (e) {
-      if (this.searchError) {
-        this.searchError(e);
-      }
+      this.args.searchError?.(e);
       return [];
     } finally {
       this.loading = false;

--- a/assets/javascripts/discourse/components/user-location.gjs
+++ b/assets/javascripts/discourse/components/user-location.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { geoLocationFormat } from "../lib/location-utilities";
@@ -113,6 +114,7 @@ export default class LocationMapComponent extends Component {
         <DButton
           class="widget-button btn btn-default btn-show-map btn-small btn-icon-text btn-transparent"
           @action={{this.toggleMap}}
+          @disabled={{not this.canShowMap}}
         >
           {{dIcon "location-dot"}}
           <div class="location-label">

--- a/assets/javascripts/discourse/components/user-location.gjs
+++ b/assets/javascripts/discourse/components/user-location.gjs
@@ -4,7 +4,7 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import { not } from "discourse/truth-helpers";
+import { and, not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { geoLocationFormat } from "../lib/location-utilities";
@@ -114,7 +114,7 @@ export default class LocationMapComponent extends Component {
         <DButton
           class="widget-button btn btn-default btn-show-map btn-small btn-icon-text btn-transparent"
           @action={{this.toggleMap}}
-          @disabled={{not this.canShowMap}}
+          @disabled={{and (not this.showMap) (not this.canShowMap)}}
         >
           {{dIcon "location-dot"}}
           <div class="location-label">

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.4
+# version: 7.3.5
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/spec/system/user_profile_location_visibility_spec.rb
+++ b/spec/system/user_profile_location_visibility_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "User profile and user card location visibility" do
       expect(page).to have_css(".replace-location .user-profile-location", visible: true, wait: 5)
       expect(page).to have_css(
         ".replace-location .user-profile-location .location-label",
+        text: "London, United Kingdom",
         visible: true,
         wait: 5,
       )
@@ -93,6 +94,7 @@ RSpec.describe "User profile and user card location visibility" do
       )
       expect(page).to have_css(
         "#user-card .location-and-website .replace-location .location .location-label",
+        text: "London, United Kingdom",
         visible: true,
       )
     end

--- a/test/javascripts/acceptance/topic-location-input-fields-disabled-test.js
+++ b/test/javascripts/acceptance/topic-location-input-fields-disabled-test.js
@@ -1,7 +1,8 @@
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, fillIn, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
 import locationFixtures from "../fixtures/location-fixtures";
 import siteFixtures from "../fixtures/site-fixtures";
 import topicFixtures from "../fixtures/topic-fixtures";
@@ -9,6 +10,12 @@ import topicFixtures from "../fixtures/topic-fixtures";
 acceptance(
   "Topic - Show Correct Location after entering location with Input Fields Disabled",
   function (needs) {
+    let searchShouldFail;
+
+    needs.hooks.beforeEach(() => {
+      searchShouldFail = false;
+    });
+
     needs.user({
       username: "demetria_gutmann",
       id: 134,
@@ -24,7 +31,13 @@ acceptance(
       const topicResponse = cloneJSON(topicFixtures["/t/51/1.json"]);
       server.get("/t/51/1.json", () => helper.response(topicResponse));
       const locationResponse = cloneJSON(locationFixtures["location.json"]);
-      server.get("/locations/search", () => helper.response(locationResponse));
+      server.get("/locations/search", () => {
+        if (searchShouldFail) {
+          return helper.response(500, { errors: ["Search failed"] });
+        }
+
+        return helper.response(locationResponse);
+      });
     });
 
     test("enter Topic location via dialogue without address fields", async function (assert) {
@@ -50,6 +63,24 @@ acceptance(
       assert
         .dom("button.add-location-btn span.d-button-label")
         .hasText("Home Sweet Home, L3 1EG, Liverpool, United Kingdom");
+    });
+
+    test("show location search errors", async function (assert) {
+      searchShouldFail = true;
+
+      await visit("/t/online-learning/51/1");
+      await click("a.fancy-title");
+      await click("button.add-location-btn");
+      await click(".location-selector .d-multi-select-trigger");
+      await fillIn(".d-multi-select__search-input", "invalid location");
+      await waitFor(".add-location-modal .alert");
+
+      assert
+        .dom(".add-location-modal .alert")
+        .hasText(
+          i18n("location.errors.search"),
+          "the search error is shown in the modal"
+        );
     });
   }
 );

--- a/test/javascripts/acceptance/topic-location-input-fields-enabled-test.js
+++ b/test/javascripts/acceptance/topic-location-input-fields-enabled-test.js
@@ -103,3 +103,37 @@ acceptance(
     });
   }
 );
+
+acceptance("Topic - Skip Empty Location Searches", function (needs) {
+  needs.user({
+    username: "demetria_gutmann",
+    id: 134,
+  });
+  needs.settings({
+    location_enabled: true,
+    location_geocoding: "optional",
+    location_input_fields_enabled: true,
+    location_input_fields: "street",
+    location_auto_infer_street_from_address_data: true,
+  });
+  needs.site(cloneJSON(siteFixtures["site.json"]));
+  needs.pretender((server, helper) => {
+    const topicResponse = cloneJSON(topicFixtures["/t/51/1.json"]);
+    topicResponse.location = null;
+    server.get("/t/51/1.json", () => helper.response(topicResponse));
+
+    const locationResponse = cloneJSON(locationFixtures["location.json"]);
+    server.get("/locations/search", () => helper.response(locationResponse));
+  });
+
+  test("does not search without location details", async function (assert) {
+    await visit("/t/online-learning/51/1");
+    await click("a.fancy-title");
+    await click("button.add-location-btn");
+    await click("button.location-search");
+
+    assert
+      .dom(".location-results")
+      .doesNotExist("no location results are shown for an empty search");
+  });
+});

--- a/test/javascripts/acceptance/topic-location-input-fields-enabled-test.js
+++ b/test/javascripts/acceptance/topic-location-input-fields-enabled-test.js
@@ -122,8 +122,9 @@ acceptance("Topic - Skip Empty Location Searches", function (needs) {
     topicResponse.location = null;
     server.get("/t/51/1.json", () => helper.response(topicResponse));
 
-    const locationResponse = cloneJSON(locationFixtures["location.json"]);
-    server.get("/locations/search", () => helper.response(locationResponse));
+    server.get("/locations/search", () => {
+      throw new Error("Empty location search reached the server");
+    });
   });
 
   test("does not search without location details", async function (assert) {

--- a/test/javascripts/component/user-location-test.gjs
+++ b/test/javascripts/component/user-location-test.gjs
@@ -1,4 +1,4 @@
-import { render } from "@ember/test-helpers";
+import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import UserLocation from "discourse/plugins/discourse-locations/discourse/components/user-location";
@@ -6,16 +6,20 @@ import UserLocation from "discourse/plugins/discourse-locations/discourse/compon
 module("Integration | Component | UserLocation", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("disables the map button when another Leaflet map is present", async function (assert) {
+  hooks.beforeEach(function () {
     this.site.country_codes = [{ code: "gb", name: "United Kingdom" }];
     this.user = {
       geo_location: {
         address: "London, United Kingdom",
         city: "London",
         countrycode: "gb",
+        lat: 51.5072,
+        lon: -0.1276,
       },
     };
+  });
 
+  test("disables the map button when another Leaflet map is present", async function (assert) {
     await render(
       <template>
         <div class="leaflet-container"></div>
@@ -26,5 +30,20 @@ module("Integration | Component | UserLocation", function (hooks) {
     assert
       .dom(".btn-show-map")
       .isDisabled("the user map cannot be opened alongside another map");
+  });
+
+  test("allows the user to close the profile map", async function (assert) {
+    await render(<template><UserLocation @user={{this.user}} /></template>);
+
+    await click(".btn-show-map");
+
+    assert.dom("#locations-map").exists("the profile map opens");
+    assert
+      .dom(".btn-show-map")
+      .isNotDisabled("the map button remains available while its map is open");
+
+    await click(".btn-show-map");
+
+    assert.dom("#locations-map").doesNotExist("the profile map closes");
   });
 });

--- a/test/javascripts/component/user-location-test.gjs
+++ b/test/javascripts/component/user-location-test.gjs
@@ -1,0 +1,30 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import UserLocation from "discourse/plugins/discourse-locations/discourse/components/user-location";
+
+module("Integration | Component | UserLocation", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("disables the map button when another Leaflet map is present", async function (assert) {
+    this.site.country_codes = [{ code: "gb", name: "United Kingdom" }];
+    this.user = {
+      geo_location: {
+        address: "London, United Kingdom",
+        city: "London",
+        countrycode: "gb",
+      },
+    };
+
+    await render(
+      <template>
+        <div class="leaflet-container"></div>
+        <UserLocation @user={{this.user}} />
+      </template>
+    );
+
+    assert
+      .dom(".btn-show-map")
+      .isDisabled("the user map cannot be opened alongside another map");
+  });
+});


### PR DESCRIPTION
Previously, location search errors could be swallowed, empty location forms still triggered geocoding requests, and profile map buttons could open alongside an existing Leaflet map.

This change routes errors to the component callback, guards empty searches, restores map button protection, and adds regression coverage for those behaviors and rendered location labels.