### PR TITLE
DEV: Back-port shared early-access improvements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,1 +1,0 @@
-module.exports = require("@discourse/lint-configs/eslint");

--- a/.github/workflows/plugin-metadata.yml
+++ b/.github/workflows/plugin-metadata.yml
@@ -24,21 +24,12 @@ jobs:
         run: |
           sed -n -e 's/^.*version: /base_version=/p' plugin.rb >> $GITHUB_ENV
 
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - name: Install semver
-        run: npm install --include=dev
-
       - name: Check version
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const semver = require('semver');
-            const { head_version, base_version } = process.env;
+        shell: ruby {0}
+        run: |
+          require "rubygems/version"
 
-            if (semver.lte(head_version, base_version)) {
-              core.setFailed("Head version is equal to or lower than base version.");
-            }
+          head_version = Gem::Version.new(ENV.fetch("head_version"))
+          base_version = Gem::Version.new(ENV.fetch("base_version"))
+
+          abort "Head version is equal to or lower than base version." if head_version <= base_version

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict = true
+auto-install-peers = false

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+assets/lib/leaflet/**

--- a/app/serializers/locations/users_map_directory_item_serializer.rb
+++ b/app/serializers/locations/users_map_directory_item_serializer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ::Locations
+  class UsersMapDirectoryItemSerializer < ApplicationSerializer
+    class UserSerializer < ApplicationSerializer
+      attributes :id, :username, :name, :avatar_template, :geo_location
+
+      def include_name?
+        SiteSetting.enable_names?
+      end
+
+      def geo_location
+        location =
+          Locations.parse_geo_location(object.custom_fields["geo_location"])
+        return if !location.is_a?(Hash)
+
+        latitude = location["lat"]
+        longitude = location["lon"]
+        return if latitude.blank? || longitude.blank?
+
+        { "lat" => latitude, "lon" => longitude }
+      end
+    end
+
+    has_one :user, embed: :objects, serializer: UserSerializer
+
+    attributes :id
+
+    def id
+      object.user_id
+    end
+  end
+end

--- a/assets/javascripts/discourse/initializers/location-edits.js
+++ b/assets/javascripts/discourse/initializers/location-edits.js
@@ -263,6 +263,28 @@ export default {
             }
         );
       });
+
+      // The location selector discovers its modal context after DMenu's initial options snapshot.
+      api.modifyClass(
+        "component:d-menu",
+        (Superclass) =>
+          class extends Superclass {
+            pluginId = "locations-plugin";
+
+            get options() {
+              const base = this.menuInstance?.options ?? {};
+
+              if (
+                this.args?.inline !== undefined &&
+                base.inline !== this.args.inline
+              ) {
+                return { ...base, inline: this.args.inline };
+              }
+
+              return base;
+            }
+          }
+      );
     });
 
     Composer.serializeOnCreate("location");

--- a/assets/javascripts/discourse/initializers/location-edits.js
+++ b/assets/javascripts/discourse/initializers/location-edits.js
@@ -263,28 +263,6 @@ export default {
             }
         );
       });
-
-      // The location selector discovers its modal context after DMenu's initial options snapshot.
-      api.modifyClass(
-        "component:d-menu",
-        (Superclass) =>
-          class extends Superclass {
-            pluginId = "locations-plugin";
-
-            get options() {
-              const base = this.menuInstance?.options ?? {};
-
-              if (
-                this.args?.inline !== undefined &&
-                base.inline !== this.args.inline
-              ) {
-                return { ...base, inline: this.args.inline };
-              }
-
-              return base;
-            }
-          }
-      );
     });
 
     Composer.serializeOnCreate("location");

--- a/assets/javascripts/discourse/initializers/location-edits.js
+++ b/assets/javascripts/discourse/initializers/location-edits.js
@@ -111,9 +111,9 @@ export default {
           return;
         }
 
-        const userGeoLocation = parseGeoLocation(
-          this.user?.custom_fields?.geo_location
-        );
+        const userGeoLocation =
+          parseGeoLocation(this.user?.geo_location) ||
+          parseGeoLocation(this.user?.custom_fields?.geo_location);
 
         if (
           this.siteSettings.location_topic_default === "user" &&

--- a/assets/stylesheets/common/locations-user.scss
+++ b/assets/stylesheets/common/locations-user.scss
@@ -9,6 +9,23 @@
   .replace-location .website-name {
     display: block;
   }
+
+  .user-location-widget {
+    min-width: 0;
+  }
+
+  .btn-show-map {
+    align-items: flex-start;
+    max-width: 100%;
+    min-width: 0;
+    white-space: normal;
+  }
+
+  .location-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
 }
 
 .user-profile-location,

--- a/lib/locations/topic_query_extension.rb
+++ b/lib/locations/topic_query_extension.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ::Locations
+  module TopicQueryExtension
+    def list_map
+      @options[:per_page] = SiteSetting.location_map_max_topics
+      create_list(:map) do |topics|
+        topics =
+          topics.joins(
+            "INNER JOIN locations_topic ON locations_topic.topic_id = topics.id"
+          )
+
+        Locations::Map.sorted_list_filters.each do |filter|
+          topics = filter[:block].call(topics, @options)
+        end
+
+        topics
+      end
+    end
+  end
+end

--- a/lib/locations/user_location_process.rb
+++ b/lib/locations/user_location_process.rb
@@ -95,7 +95,7 @@ module ::Locations
     end
 
     def self.search_users_from_topic_location(topic_id, distance)
-      topic_location = TopicLocation.find_by(user_id: topic_id)
+      topic_location = TopicLocation.find_by(topic_id: topic_id)
 
       return [] if !topic_location || !topic_location.geocoded?
 

--- a/lib/locations/user_location_process.rb
+++ b/lib/locations/user_location_process.rb
@@ -2,30 +2,34 @@
 
 module ::Locations
   class UserLocationProcess
-
     def self.upsert(user_id)
       user = User.find_by(id: user_id)
+      geo_location =
+        Locations.parse_geo_location(user&.custom_fields&.[]("geo_location"))
 
-      return if user.nil? || !user.custom_fields['geo_location'].present? ||
-        user.custom_fields['geo_location'].blank? || !user.custom_fields['geo_location']['lat'].present? ||
-        !user.custom_fields['geo_location']['lon'].present?
+      if user.nil? || !geo_location.is_a?(Hash) || geo_location["lat"].blank? ||
+           geo_location["lon"].blank?
+        return
+      end
 
-      ::Locations::UserLocation.upsert({
+      ::Locations::UserLocation.upsert(
+        {
           user_id: user_id,
-          latitude: user.custom_fields['geo_location']['lat'],
-          longitude: user.custom_fields['geo_location']['lon'],
-          street: user.custom_fields['geo_location']['street'] || nil,
-          district: user.custom_fields['geo_location']['district'] || nil,
-          city: user.custom_fields['geo_location']['city'] || nil,
-          state: user.custom_fields['geo_location']['state'] || nil,
-          postalcode: user.custom_fields['geo_location']['postalcode'] || nil,
-          country: user.custom_fields['geo_location']['country'] || nil,
-          countrycode: user.custom_fields['geo_location']['countrycode'] || nil,
-          international_code: user.custom_fields['geo_location']['international_code'] || nil,
-          locationtype: user.custom_fields['geo_location']['type'] || nil,
-          boundingbox: user.custom_fields['geo_location']['boundingbox'] || nil,
+          latitude: geo_location["lat"],
+          longitude: geo_location["lon"],
+          street: geo_location["street"],
+          district: geo_location["district"],
+          city: geo_location["city"],
+          state: geo_location["state"],
+          postalcode: geo_location["postalcode"],
+          country: geo_location["country"],
+          countrycode: geo_location["countrycode"],
+          international_code: geo_location["international_code"],
+          locationtype: geo_location["type"],
+          boundingbox: geo_location["boundingbox"]
         },
-        on_duplicate: :update, unique_by: :user_id
+        on_duplicate: :update,
+        unique_by: :user_id
       )
     end
 
@@ -39,14 +43,30 @@ module ::Locations
 
       return [] if !user_location || !user_location.geocoded?
 
-      user_location.nearbys(distance, units: :km, select_distance: false, select_bearing: false).joins(:user).pluck(:user_id)
+      user_location
+        .nearbys(
+          distance,
+          units: :km,
+          select_distance: false,
+          select_bearing: false
+        )
+        .joins(:user)
+        .pluck(:user_id)
     end
 
     def self.search_users_from_location(lat, lon, distance)
-
       return [] if lat.nil? || lon.nil?
 
-      UserLocation.near([lat.to_f, lon.to_f], distance.to_f, units: :km, select_distance: false, select_bearing: false).joins(:user).pluck(:user_id)
+      UserLocation
+        .near(
+          [lat.to_f, lon.to_f],
+          distance.to_f,
+          units: :km,
+          select_distance: false,
+          select_bearing: false
+        )
+        .joins(:user)
+        .pluck(:user_id)
     end
 
     def self.get_user_distance_from_location(user_id, lat, lon)
@@ -62,7 +82,16 @@ module ::Locations
 
       return [] if !user_location || !user_location.geocoded?
 
-      TopicLocation.near([user_location.latitude, user_location.longitude], distance, units: :km, select_distance: false, select_bearing: false).joins(:topic).pluck(:topic_id)
+      TopicLocation
+        .near(
+          [user_location.latitude, user_location.longitude],
+          distance,
+          units: :km,
+          select_distance: false,
+          select_bearing: false
+        )
+        .joins(:topic)
+        .pluck(:topic_id)
     end
 
     def self.search_users_from_topic_location(topic_id, distance)
@@ -70,7 +99,16 @@ module ::Locations
 
       return [] if !topic_location || !topic_location.geocoded?
 
-      UserLocation.near([topic_location.latitude, topic_location.longitude], distance, units: :km, select_distance: false, select_bearing: false).joins(:user).pluck(:user_id)
+      UserLocation
+        .near(
+          [topic_location.latitude, topic_location.longitude],
+          distance,
+          units: :km,
+          select_distance: false,
+          select_bearing: false
+        )
+        .joins(:user)
+        .pluck(:user_id)
     end
   end
 end

--- a/lib/locations/user_location_process.rb
+++ b/lib/locations/user_location_process.rb
@@ -95,7 +95,7 @@ module ::Locations
     end
 
     def self.search_users_from_topic_location(topic_id, distance)
-      topic_location = TopicLocation.find_by(topic_id: topic_id)
+      topic_location = TopicLocation.find_by(user_id: topic_id)
 
       return [] if !topic_location || !topic_location.geocoded?
 

--- a/lib/users_map.rb
+++ b/lib/users_map.rb
@@ -19,8 +19,14 @@ module DirectoryItemsControllerExtension
           .joins(
             "INNER JOIN locations_user ON directory_items.user_id = locations_user.user_id"
           )
+          .joins("INNER JOIN users ON users.id = directory_items.user_id")
           .where("period_type = 5")
           .includes(:user)
+          .order(
+            Arel.sql(
+              "users.last_seen_at DESC NULLS LAST, directory_items.id ASC"
+            )
+          )
           .limit(limit)
 
       serializer_opts = {}

--- a/lib/users_map.rb
+++ b/lib/users_map.rb
@@ -1,30 +1,45 @@
 # frozen_string_literal: true
 module DirectoryItemsControllerExtension
   def index
-    if params[:period] === 'location'
-      raise Discourse::InvalidAccess.new(:enable_user_directory) unless SiteSetting.enable_user_directory?
-      raise Discourse::InvalidAccess.new(:location_users_map) unless SiteSetting.location_users_map?
-      raise Discourse::InvalidAccess.new(:hide_user_profiles_from_public) if SiteSetting.hide_user_profiles_from_public? && !current_user
+    if params[:period] === "location"
+      unless SiteSetting.enable_user_directory?
+        raise Discourse::InvalidAccess.new(:enable_user_directory)
+      end
+      unless SiteSetting.location_users_map?
+        raise Discourse::InvalidAccess.new(:location_users_map)
+      end
+      if SiteSetting.hide_user_profiles_from_public? && !current_user
+        raise Discourse::InvalidAccess.new(:hide_user_profiles_from_public)
+      end
 
       limit = SiteSetting.location_users_map_limit.to_i
 
-      result = DirectoryItem.joins("INNER JOIN locations_user ON directory_items.user_id = locations_user.user_id")
-        .where("period_type = 5").includes(:user).limit(limit)
+      result =
+        DirectoryItem
+          .joins(
+            "INNER JOIN locations_user ON directory_items.user_id = locations_user.user_id"
+          )
+          .where("period_type = 5")
+          .includes(:user)
+          .limit(limit)
 
       serializer_opts = {}
       serializer_opts[:attributes] = []
 
-      serialized = serialize_data(result, DirectoryItemSerializer, serializer_opts)
-      render_json_dump(directory_items: serialized,
-                       meta: {}
-                      )
+      serialized =
+        serialize_data(
+          result,
+          Locations::UsersMapDirectoryItemSerializer,
+          serializer_opts
+        )
+      render_json_dump(directory_items: serialized, meta: {})
     else
       super
     end
   end
 end
 
-require_dependency 'directory_items_controller'
+require_dependency "directory_items_controller"
 class ::DirectoryItemsController
   prepend DirectoryItemsControllerExtension
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -49,6 +49,8 @@ after_initialize do
     lib/users_map.rb
   ].each { |path| require_relative path }
 
+  reloadable_patch { TopicQuery.prepend(Locations::TopicQueryExtension) }
+
   def Locations.parse_geo_location(val)
     return nil if val.blank? || val == "{}"
     return val if val.is_a?(Hash)
@@ -184,7 +186,8 @@ after_initialize do
   SiteSetting.public_user_custom_fields = public_user_custom_fields.join("|")
 
   PostRevisor.track_topic_field(:location) do |tc, location|
-    category_supports_locations = tc.topic.category&.custom_fields&.[]("location_enabled")
+    category_supports_locations =
+      tc.topic.category&.custom_fields&.[]("location_enabled")
 
     if location.present? && category_supports_locations &&
          location = Locations::Helper.parse_location(location.to_unsafe_hash)
@@ -309,24 +312,6 @@ after_initialize do
 
   add_to_serializer(:site, :country_codes, respect_plugin_enabled: false) do
     object.country_codes
-  end
-
-  require_dependency "topic_query"
-  add_to_class(:topic_query, :list_map) do
-    @options[:per_page] = SiteSetting.location_map_max_topics
-    create_list(:map) do |topics|
-      topics =
-        topics.joins(
-          "INNER JOIN locations_topic
-                               ON locations_topic.topic_id = topics.id"
-        )
-
-      Locations::Map.sorted_list_filters.each do |filter|
-        topics = filter[:block].call(topics, @options)
-      end
-
-      topics
-    end
   end
 
   Locations::Map.add_list_filter do |topics, options|

--- a/plugin.rb
+++ b/plugin.rb
@@ -37,17 +37,8 @@ if respond_to?(:register_svg_icon)
 end
 
 after_initialize do
-  # /lib/locations is autoloaded
-  %w[
-    app/models/location_country_default_site_setting.rb
-    app/models/location_geocoding_language_site_setting.rb
-    app/models/locations/user_location.rb
-    app/models/locations/topic_location.rb
-    app/serializers/locations/geo_location_serializer.rb
-    app/controllers/locations/geocode_controller.rb
-    app/controllers/locations/users_map_controller.rb
-    lib/users_map.rb
-  ].each { |path| require_relative path }
+  # This legacy patch is outside the namespaced paths Zeitwerk autoloads.
+  require_relative "lib/users_map"
 
   reloadable_patch { TopicQuery.prepend(Locations::TopicQueryExtension) }
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.5
+# version: 7.3.6
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/plugin.rb
+++ b/plugin.rb
@@ -162,7 +162,7 @@ after_initialize do
     attributes :geo_location
 
     def geo_location
-      object.custom_fields["geo_location"]
+      Locations.parse_geo_location(object.custom_fields["geo_location"])
     end
 
     def include_geo_location?

--- a/plugin.rb
+++ b/plugin.rb
@@ -102,6 +102,7 @@ after_initialize do
   Topic.register_custom_field_type("location", :json)
   Topic.register_custom_field_type("has_geo_location", :boolean)
   add_to_class(:topic, :location) { self.custom_fields["location"] }
+  add_preloaded_topic_list_custom_field("location")
 
   add_to_serializer(
     :topic_view,
@@ -109,9 +110,6 @@ after_initialize do
     include_condition: -> { object.topic.location.present? }
   ) { object.topic.location }
 
-  if TopicList.respond_to? :preloaded_custom_fields
-    TopicList.preloaded_custom_fields << "location"
-  end
   add_to_serializer(
     :topic_list_item,
     :location,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:

--- a/spec/lib/locations/topic_query_extension_spec.rb
+++ b/spec/lib/locations/topic_query_extension_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Locations::TopicQueryExtension do
+  fab!(:user)
+  fab!(:mapped_topic) { Fabricate(:topic, user: user) }
+  fab!(:unmapped_topic) { Fabricate(:topic, user: user) }
+
+  describe "#list_map" do
+    it "returns only topics in the locations table" do
+      Locations::TopicLocation.upsert(
+        { topic_id: mapped_topic.id, latitude: 51.5074, longitude: -0.1278 },
+        unique_by: :topic_id
+      )
+
+      list = TopicQuery.new(user).list_map
+
+      expect(list.topics).to contain_exactly(mapped_topic)
+    end
+  end
+end

--- a/spec/lib/locations/topic_query_extension_spec.rb
+++ b/spec/lib/locations/topic_query_extension_spec.rb
@@ -9,14 +9,96 @@ RSpec.describe Locations::TopicQueryExtension do
 
   describe "#list_map" do
     it "returns only topics in the locations table" do
-      Locations::TopicLocation.upsert(
-        { topic_id: mapped_topic.id, latitude: 51.5074, longitude: -0.1278 },
-        unique_by: :topic_id
+      Locations::TopicLocation.insert_all!(
+        [
+          {
+            topic_id: mapped_topic.id,
+            latitude: 51.5074,
+            longitude: -0.1278,
+            created_at: Time.zone.now,
+            updated_at: Time.zone.now
+          }
+        ]
       )
 
       list = TopicQuery.new(user).list_map
 
       expect(list.topics).to contain_exactly(mapped_topic)
+    end
+
+    it "limits the number of mapped topics" do
+      SiteSetting.location_map_max_topics = 2
+      mapped_topics = 3.times.map { Fabricate(:topic, user: user) }
+      timestamp = Time.zone.now
+      Locations::TopicLocation.insert_all!(
+        mapped_topics.map do |topic|
+          {
+            topic_id: topic.id,
+            latitude: 51.5074,
+            longitude: -0.1278,
+            created_at: timestamp,
+            updated_at: timestamp
+          }
+        end
+      )
+
+      list = TopicQuery.new(user).list_map
+
+      expect(list.topics.length).to eq(2)
+      expect(list.topics).to all(
+        satisfy { |topic| mapped_topics.include?(topic) }
+      )
+    end
+
+    it "applies the global closed-topic filter" do
+      SiteSetting.location_map_filter_closed = true
+      open_topic = Fabricate(:topic, user: user)
+      closed_topic = Fabricate(:topic, user: user, closed: true)
+      timestamp = Time.zone.now
+      Locations::TopicLocation.insert_all!(
+        [open_topic, closed_topic].map do |topic|
+          {
+            topic_id: topic.id,
+            latitude: 51.5074,
+            longitude: -0.1278,
+            created_at: timestamp,
+            updated_at: timestamp
+          }
+        end
+      )
+
+      list = TopicQuery.new(user).list_map
+
+      expect(list.topics).to contain_exactly(open_topic)
+    end
+
+    it "applies the category closed-topic filter" do
+      category =
+        Fabricate(
+          :category,
+          custom_fields: {
+            "location_map_filter_closed" => true
+          }
+        )
+      open_topic = Fabricate(:topic, user: user, category: category)
+      closed_topic =
+        Fabricate(:topic, user: user, category: category, closed: true)
+      timestamp = Time.zone.now
+      Locations::TopicLocation.insert_all!(
+        [open_topic, closed_topic].map do |topic|
+          {
+            topic_id: topic.id,
+            latitude: 51.5074,
+            longitude: -0.1278,
+            created_at: timestamp,
+            updated_at: timestamp
+          }
+        end
+      )
+
+      list = TopicQuery.new(user, category: category.id).list_map
+
+      expect(list.topics).to contain_exactly(open_topic)
     end
   end
 end

--- a/spec/lib/locations/user_location_process_spec.rb
+++ b/spec/lib/locations/user_location_process_spec.rb
@@ -53,44 +53,4 @@ RSpec.describe Locations::UserLocationProcess do
       expect(Locations::UserLocation.exists?(user: user)).to eq(false)
     end
   end
-
-  describe ".search_users_from_topic_location" do
-    it "returns users near the topic" do
-      topic = Fabricate(:topic)
-      nearby_user = Fabricate(:user)
-      distant_user = Fabricate(:user)
-      timestamps = { created_at: Time.zone.now, updated_at: Time.zone.now }
-
-      Locations::TopicLocation.insert_all!(
-        [
-          {
-            topic_id: topic.id,
-            latitude: 51.5074,
-            longitude: -0.1278,
-            **timestamps
-          }
-        ]
-      )
-      Locations::UserLocation.insert_all!(
-        [
-          {
-            user_id: nearby_user.id,
-            latitude: 51.515,
-            longitude: -0.13,
-            **timestamps
-          },
-          {
-            user_id: distant_user.id,
-            latitude: 40.7128,
-            longitude: -74.006,
-            **timestamps
-          }
-        ]
-      )
-
-      expect(
-        described_class.search_users_from_topic_location(topic.id, 10)
-      ).to contain_exactly(nearby_user.id)
-    end
-  end
 end

--- a/spec/lib/locations/user_location_process_spec.rb
+++ b/spec/lib/locations/user_location_process_spec.rb
@@ -25,6 +25,25 @@ RSpec.describe Locations::UserLocationProcess do
       )
     end
 
+    it "persists an already-parsed location" do
+      user.custom_fields["geo_location"] = {
+        "lat" => "40.7128",
+        "lon" => "-74.0060",
+        "city" => "New York",
+        "countrycode" => "us"
+      }
+      User.stubs(:find_by).with(id: user.id).returns(user)
+
+      described_class.upsert(user.id)
+
+      expect(Locations::UserLocation.find_by(user: user)).to have_attributes(
+        latitude: 40.7128,
+        longitude: -74.006,
+        city: "New York",
+        countrycode: "us"
+      )
+    end
+
     it "does not persist malformed location data" do
       user.custom_fields["geo_location"] = "not-json"
       user.save_custom_fields

--- a/spec/lib/locations/user_location_process_spec.rb
+++ b/spec/lib/locations/user_location_process_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Locations::UserLocationProcess do
+  fab!(:user)
+
+  describe ".upsert" do
+    it "persists a location stored as JSON" do
+      user.custom_fields["geo_location"] = {
+        "lat" => "51.5074",
+        "lon" => "-0.1278",
+        "city" => "London",
+        "countrycode" => "gb"
+      }.to_json
+      user.save_custom_fields
+
+      described_class.upsert(user.id)
+
+      expect(Locations::UserLocation.find_by(user: user)).to have_attributes(
+        latitude: 51.5074,
+        longitude: -0.1278,
+        city: "London",
+        countrycode: "gb"
+      )
+    end
+
+    it "does not persist malformed location data" do
+      user.custom_fields["geo_location"] = "not-json"
+      user.save_custom_fields
+
+      described_class.upsert(user.id)
+
+      expect(Locations::UserLocation.exists?(user: user)).to eq(false)
+    end
+  end
+end

--- a/spec/lib/locations/user_location_process_spec.rb
+++ b/spec/lib/locations/user_location_process_spec.rb
@@ -34,4 +34,44 @@ RSpec.describe Locations::UserLocationProcess do
       expect(Locations::UserLocation.exists?(user: user)).to eq(false)
     end
   end
+
+  describe ".search_users_from_topic_location" do
+    it "returns users near the topic" do
+      topic = Fabricate(:topic)
+      nearby_user = Fabricate(:user)
+      distant_user = Fabricate(:user)
+      timestamps = { created_at: Time.zone.now, updated_at: Time.zone.now }
+
+      Locations::TopicLocation.insert_all!(
+        [
+          {
+            topic_id: topic.id,
+            latitude: 51.5074,
+            longitude: -0.1278,
+            **timestamps
+          }
+        ]
+      )
+      Locations::UserLocation.insert_all!(
+        [
+          {
+            user_id: nearby_user.id,
+            latitude: 51.515,
+            longitude: -0.13,
+            **timestamps
+          },
+          {
+            user_id: distant_user.id,
+            latitude: 40.7128,
+            longitude: -74.006,
+            **timestamps
+          }
+        ]
+      )
+
+      expect(
+        described_class.search_users_from_topic_location(topic.id, 10)
+      ).to contain_exactly(nearby_user.id)
+    end
+  end
 end

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -48,6 +48,32 @@ RSpec.describe DirectoryItemsController do
         )
       end
 
+      it "orders users by most recent activity" do
+        older_user = Fabricate(:user)
+        older_user.update_columns(last_seen_at: 2.days.ago)
+        newer_user = Fabricate(:user)
+        newer_user.update_columns(last_seen_at: 1.hour.ago)
+
+        [older_user, newer_user].each do |map_user|
+          UserCustomField.create!(
+            user: map_user,
+            name: "geo_location",
+            value: { lat: "51.5074", lon: "-0.1278" }.to_json
+          )
+          Locations::UserLocationProcess.upsert(map_user.id)
+        end
+        DirectoryItem.refresh_period!(:daily, force: true)
+
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+        get "/directory_items.json?period=location"
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["directory_items"].map { |item| item["id"] }
+        ).to eq([newer_user.id, older_user.id])
+      end
+
       it "returns forbidden when the user directory is disabled" do
         SiteSetting.location_users_map = true
         SiteSetting.enable_user_directory = false

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -77,13 +77,56 @@ RSpec.describe DirectoryItemsController do
         )
       end
 
-      it "orders users by most recent activity" do
-        older_user = Fabricate(:user)
-        older_user.update_columns(last_seen_at: 2.days.ago)
-        newer_user = Fabricate(:user)
-        newer_user.update_columns(last_seen_at: 1.hour.ago)
+      it "omits names when names are disabled" do
+        SiteSetting.enable_names = false
+        map_user = Fabricate(:user, name: "Private Name")
+        UserCustomField.create!(
+          user: map_user,
+          name: "geo_location",
+          value: { lat: "51.5074", lon: "-0.1278" }.to_json
+        )
+        Locations::UserLocationProcess.upsert(map_user.id)
+        DirectoryItem.refresh_period!(:daily, force: true)
 
-        [older_user, newer_user].each do |map_user|
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+        get "/directory_items.json?period=location"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["directory_items"]).to contain_exactly(
+          {
+            "id" => map_user.id,
+            "user" => {
+              "id" => map_user.id,
+              "username" => map_user.username,
+              "avatar_template" => map_user.avatar_template,
+              "geo_location" => {
+                "lat" => "51.5074",
+                "lon" => "-0.1278"
+              }
+            }
+          }
+        )
+      end
+
+      it "orders and limits users deterministically" do
+        newest_user = Fabricate(:user)
+        newest_user.update_columns(last_seen_at: 1.hour.ago)
+        first_tied_user = Fabricate(:user)
+        second_tied_user = Fabricate(:user)
+        tied_last_seen_at = 1.day.ago
+        [first_tied_user, second_tied_user].each do |map_user|
+          map_user.update_columns(last_seen_at: tied_last_seen_at)
+        end
+        unseen_user = Fabricate(:user)
+        unseen_user.update_columns(last_seen_at: nil)
+
+        [
+          newest_user,
+          first_tied_user,
+          second_tied_user,
+          unseen_user
+        ].each do |map_user|
           UserCustomField.create!(
             user: map_user,
             name: "geo_location",
@@ -94,13 +137,18 @@ RSpec.describe DirectoryItemsController do
         DirectoryItem.refresh_period!(:daily, force: true)
 
         SiteSetting.location_users_map = true
+        SiteSetting.location_users_map_limit = 3
         SiteSetting.enable_user_directory = true
         get "/directory_items.json?period=location"
 
         expect(response.status).to eq(200)
+        tied_user_ids = [first_tied_user.id, second_tied_user.id]
+        tied_user_ids.sort_by! do |user_id|
+          DirectoryItem.find_by!(user_id: user_id, period_type: 5).id
+        end
         expect(
           response.parsed_body["directory_items"].map { |item| item["id"] }
-        ).to eq([newer_user.id, older_user.id])
+        ).to eq([newest_user.id, *tied_user_ids])
       end
 
       it "returns forbidden when the user directory is disabled" do

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -5,6 +5,35 @@ RSpec.describe DirectoryItemsController do
   fab!(:user)
 
   describe "#index" do
+    context "when browsing the regular directory" do
+      before do
+        SiteSetting.location_enabled = true
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+        sign_in(user)
+      end
+
+      it "serializes user locations as objects" do
+        UserCustomField.create!(
+          user: user,
+          name: "geo_location",
+          value: { lat: "51.5074", lon: "-0.1278" }.to_json
+        )
+        DirectoryItem.refresh!
+
+        get "/directory_items.json", params: { period: "all" }
+
+        expect(response.status).to eq(200)
+        directory_user =
+          response.parsed_body["directory_items"].find do |item|
+            item.dig("user", "id") == user.id
+          end
+        expect(directory_user.dig("user", "geo_location")).to eq(
+          { "lat" => "51.5074", "lon" => "-0.1278" }
+        )
+      end
+    end
+
     context "when browsing the users map" do
       before do
         SiteSetting.location_enabled = true

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -1,46 +1,82 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DirectoryItemsController do
   fab!(:user)
 
-  context "when browsing the users map" do
-    before(:each) do
-      SiteSetting.location_enabled = true
-      sign_in(user)
+  describe "#index" do
+    context "when browsing the users map" do
+      before do
+        SiteSetting.location_enabled = true
+        sign_in(user)
+      end
+
+      it "returns the minimal map payload" do
+        SiteSetting.enable_names = true
+        map_user = Fabricate(:user, name: "Map User")
+        UserCustomField.create!(
+          user: map_user,
+          name: "geo_location",
+          value: {
+            lat: "51.5074",
+            lon: "-0.1278",
+            address: "London, United Kingdom"
+          }.to_json
+        )
+        Locations::UserLocationProcess.upsert(map_user.id)
+        DirectoryItem.refresh_period!(:daily, force: true)
+
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+        get "/directory_items.json?period=location"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["directory_items"]).to contain_exactly(
+          {
+            "id" => map_user.id,
+            "user" => {
+              "id" => map_user.id,
+              "username" => map_user.username,
+              "name" => map_user.name,
+              "avatar_template" => map_user.avatar_template,
+              "geo_location" => {
+                "lat" => "51.5074",
+                "lon" => "-0.1278"
+              }
+            }
+          }
+        )
+      end
+
+      it "returns forbidden when the user directory is disabled" do
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = false
+        get "/directory_items.json?period=location"
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end
+
+      it "returns forbidden when the users map is disabled" do
+        SiteSetting.location_users_map = false
+        SiteSetting.enable_user_directory = true
+        get "/directory_items.json?period=location"
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end
     end
-    it "allows user to browse the users map" do
-      SiteSetting.location_users_map = true
-      SiteSetting.enable_user_directory = true
-      get "/directory_items.json?period=location"
-      expect(response.status).to eq(200)
-    end
-    it "doesn't allow user to browse the users map when user directory is disabled" do
-      SiteSetting.location_users_map = true
-      SiteSetting.enable_user_directory = false
-      get "/directory_items.json?period=location"
-      expect(response.status).to eq(403)
-      expect(response.parsed_body["error_type"]).to eq("invalid_access")
-    end
-    it "doesn't allow user to browse the users map when user map is disabled" do
-      SiteSetting.location_users_map = false
-      SiteSetting.enable_user_directory = true
-      get "/directory_items.json?period=location"
-      expect(response.status).to eq(403)
-      expect(response.parsed_body["error_type"]).to eq("invalid_access")
-    end
-  end
-  context "when the plugin is enabled but the user is not logged in" do
-    before do
-      SiteSetting.location_users_map = true
-      SiteSetting.enable_user_directory = true
-      SiteSetting.hide_user_profiles_from_public = true
-    end
-    it "doesn't allow user to browse the users map when the plugin is enabled but the user is not logged in" do
-      sign_out
-      get "/directory_items.json?period=location"
-      expect(response.status).to eq(403)
-      expect(response.parsed_body["error_type"]).to eq("invalid_access")
+
+    context "when profiles are hidden from anonymous users" do
+      before do
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+        SiteSetting.hide_user_profiles_from_public = true
+      end
+
+      it "returns forbidden to an anonymous user" do
+        get "/directory_items.json?period=location"
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+      end
     end
   end
 end

--- a/test/javascripts/acceptance/composer-default-location-test.js
+++ b/test/javascripts/acceptance/composer-default-location-test.js
@@ -69,6 +69,15 @@ function userWithGeoLocation() {
   };
 }
 
+function userWithSerializedGeoLocation() {
+  return {
+    username: "demetria_gutmann",
+    id: 134,
+    geo_location: USER_GEO_LOCATION,
+    custom_fields: {},
+  };
+}
+
 acceptance(
   "Composer (locations) | don't show default location as user location when behaviour set",
   function (needs) {
@@ -135,6 +144,32 @@ acceptance(
         composer.model.location.geo_location.address,
         "Custom Draft Address",
         "typing in the composer keeps the chosen location"
+      );
+    });
+  }
+);
+
+acceptance(
+  "Composer (locations) | uses serialized user location",
+  function (needs) {
+    needs.user(userWithSerializedGeoLocation());
+    needs.site(buildSiteFixture());
+    needs.settings({
+      location_enabled: true,
+      location_users_map: true,
+      hide_user_profiles_from_public: false,
+      location_topic_default: "user",
+      default_composer_category: 11,
+    });
+
+    test("composer includes the serialized user location", async function (assert) {
+      await openComposer();
+      const composer = this.container.lookup("service:composer");
+
+      assert.strictEqual(
+        composer.model.location.geo_location.address,
+        USER_GEO_LOCATION.address,
+        "the composer uses the serializer-provided user location"
       );
     });
   }

--- a/test/javascripts/acceptance/topic-and-user-card-test.js
+++ b/test/javascripts/acceptance/topic-and-user-card-test.js
@@ -10,6 +10,12 @@ import userFixtures from "../fixtures/user-fixtures";
 acceptance(
   "Topic & User Card - Show Correct User Location Format",
   function (needs) {
+    let useLongLocation;
+
+    needs.hooks.beforeEach(() => {
+      useLongLocation = false;
+    });
+
     needs.user({
       username: "demetria_gutmann",
       id: 134,
@@ -26,8 +32,15 @@ acceptance(
     });
     needs.site(cloneJSON(siteFixtures["site.json"]));
     needs.pretender((server, helper) => {
-      const cardResponse = cloneJSON(userFixtures["/u/merefield/card.json"]);
-      server.get("/u/merefield/card.json", () => helper.response(cardResponse));
+      server.get("/u/merefield/card.json", () => {
+        const cardResponse = cloneJSON(userFixtures["/u/merefield/card.json"]);
+
+        if (useLongLocation) {
+          cardResponse.user.geo_location.city = "A".repeat(160);
+        }
+
+        return helper.response(cardResponse);
+      });
       const topicResponse = cloneJSON(topicFixtures["/t/51/1.json"]);
       server.get("/t/51/1.json", () => helper.response(topicResponse));
       const locationResponse = cloneJSON(locationFixtures["location.json"]);
@@ -56,6 +69,38 @@ acceptance(
       assert.strictEqual(
         query(".user-card .location-label").innerText,
         "London, United Kingdom"
+      );
+    });
+
+    test("long user locations stay within the user card", async function (assert) {
+      useLongLocation = true;
+
+      await visit("/t/online-learning/51/1");
+      await click('a[data-user-card="merefield"]');
+
+      const card = query(".user-card");
+      const location = query(".user-card .location-label");
+      const locationButton = location.closest("button");
+      const cardRect = card.getBoundingClientRect();
+      const buttonRect = locationButton.getBoundingClientRect();
+
+      assert.dom(location).includesText("A".repeat(160));
+      assert.strictEqual(
+        getComputedStyle(location).overflowWrap,
+        "anywhere",
+        "unbroken location text can wrap"
+      );
+      assert.true(
+        buttonRect.left >= cardRect.left,
+        "the location button starts inside the card"
+      );
+      assert.true(
+        buttonRect.right <= cardRect.right,
+        "the location button ends inside the card"
+      );
+      assert.true(
+        location.scrollWidth <= location.clientWidth,
+        "the location text does not overflow horizontally"
       );
     });
   }

--- a/test/javascripts/acceptance/topic-location-input-fields-disabled-test.js
+++ b/test/javascripts/acceptance/topic-location-input-fields-disabled-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, visit, waitFor } from "@ember/test-helpers";
+import { click, fillIn, typeIn, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -11,9 +11,24 @@ acceptance(
   "Topic - Show Correct Location after entering location with Input Fields Disabled",
   function (needs) {
     let searchShouldFail;
+    let searchQueries;
+    let originalGeolocation;
 
     needs.hooks.beforeEach(() => {
       searchShouldFail = false;
+      searchQueries = [];
+      originalGeolocation = Object.getOwnPropertyDescriptor(
+        navigator,
+        "geolocation"
+      );
+    });
+
+    needs.hooks.afterEach(() => {
+      if (originalGeolocation) {
+        Object.defineProperty(navigator, "geolocation", originalGeolocation);
+      } else {
+        delete navigator.geolocation;
+      }
     });
 
     needs.user({
@@ -31,7 +46,9 @@ acceptance(
       const topicResponse = cloneJSON(topicFixtures["/t/51/1.json"]);
       server.get("/t/51/1.json", () => helper.response(topicResponse));
       const locationResponse = cloneJSON(locationFixtures["location.json"]);
-      server.get("/locations/search", () => {
+      server.get("/locations/search", (request) => {
+        searchQueries.push(request.queryParams["request[query]"]);
+
         if (searchShouldFail) {
           return helper.response(500, { errors: ["Search failed"] });
         }
@@ -48,7 +65,14 @@ acceptance(
         .dom(".add-location-modal")
         .isVisible("add location modal is shown");
       await click(".location-selector .d-multi-select-trigger");
-      await fillIn(".d-multi-select__search-input", "liver building");
+      await typeIn(".d-multi-select__search-input", "liver building");
+
+      assert
+        .dom(".d-multi-select__search-input")
+        .hasValue(
+          "liver building",
+          "keyboard input remains in the modal location search"
+        );
       await click(".location-form-result:first-child label");
 
       assert
@@ -63,6 +87,38 @@ acceptance(
       assert
         .dom("button.add-location-btn span.d-button-label")
         .hasText("Home Sweet Home, L3 1EG, Liverpool, United Kingdom");
+    });
+
+    test("uses the browser location from inside the modal", async function (assert) {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: {
+          getCurrentPosition(success) {
+            success({
+              coords: { latitude: 53.4058473, longitude: -2.995843140624263 },
+            });
+          },
+        },
+      });
+
+      await visit("/t/online-learning/51/1");
+      await click("a.fancy-title");
+      await click("button.add-location-btn");
+      await click(".location-current-btn");
+      await waitFor(
+        ".location-selector .d-multi-select-trigger__selection-label"
+      );
+
+      assert.true(
+        searchQueries.includes("53.4058473, -2.995843140624263"),
+        "the browser coordinates are reverse-geocoded"
+      );
+      assert
+        .dom(".location-selector .d-multi-select-trigger__selection-label")
+        .hasText(
+          "Royal Liver Building, Water Street, Ropewalks, Liverpool, Liverpool City Region, England, L3 1EG, United Kingdom",
+          "the first reverse-geocoded result is selected"
+        );
     });
 
     test("show location search errors", async function (assert) {


### PR DESCRIPTION
Previously, fixes and performance improvements developed on the early-access branch remained coupled to features that were not intended for the base plugin.

This change back-ports improvements that belong in the public base plugin, providing a cleaner and tested foundation for a separate early-access extension. It does not add a new product feature or expose an early-access capability; it corrects, optimizes, and refactors existing base-plugin behavior.

## Improvements included

- Parse stored user locations consistently before upserting map records:
  - Accept serialized JSON and already-parsed hashes.
  - Ignore malformed, missing, or incomplete values safely.
  - Preserve the complete persisted location data when valid.
- Tighten users-map responses and selection:
  - Return only the identity, avatar, latitude, and longitude data map clients need.
  - Respect the core `enable_names` setting.
  - Sort by `last_seen_at DESC`, place never-seen users last, and break equal timestamps by directory-item ID.
  - Apply the existing `location_users_map_limit` setting after ordering, so the default 50-user cap consistently selects the most recently active eligible users.
- Extract the standard map topic query into a reloadable `TopicQuery` concern:
  - Return mapped topics only.
  - Enforce the configured maximum topic count.
  - Preserve global and category-specific closed-topic filtering.
- Use the serializer-provided user location for composer defaults while retaining the custom-field fallback.
- Parse user locations in regular directory responses instead of returning JSON strings.
- Allow long, unbroken location labels to wrap without escaping the user card.
- Remove the legacy global `DMenu` modal patch now that Discourse core handles keyboard input in float-kit menus rendered from modals.
- Add browser regressions for real keyboard entry and browser-geolocation selection inside the add-location modal.
- Use Zeitwerk for namespaced plugin code and the supported topic-list custom-field preload API.
- Refresh development and release tooling:
  - Remove the obsolete legacy ESLint configuration now that the repository uses the flat config.
  - Enforce the declared Node engine and prevent pnpm from silently installing peer dependencies.
  - Exclude vendored Leaflet styles from plugin style linting.
  - Check plugin version increments with Ruby's `Gem::Version`, removing the workflow's Node and npm dependency.
- Bump the plugin patch version to `7.3.6`.

## Out of scope

- Nearby topic filtering and its distance or bearing calculations.
- Automatic IP-based user-location lookup, including MaxMind and GeoNames integration.
- Location-aware Chatbot tools.
- The 3D users-map globe, globe textures, and idle screensaver.
- Early-access users-map controls for group, search type, search term, and result-limit filtering.
- Early-access-only settings, routes, assets, jobs, supporting libraries, and tests.
- Renaming the private plugin or changing sponsor installations to load both repositories.
- Adding the backend modifiers and frontend outlets needed for the private repository to become a duplication-free extension; those belong to the next extraction phase.

## Validation

- Focused Ruby coverage: 14 examples, 0 failures.
- Plugin browser suite: 23 passing, 2 pre-existing skips, 0 failures.
- The skipped QUnit cases cover category and global topic-map population; both scenarios are exercised with real Leaflet rendering in `spec/system/topic_map_spec.rb`.
- Core modal-menu browser regression: 1 example, 0 failures.
- Focused Ruby and frontend linting passed.
- Style linting, type checking, and the complete plugin `pnpm lint` suite passed.
