### PR TITLE
DEV: Add users map extension seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ The Locations Plugin allows you to associate geocoded locations with topics, and
 
 ### Extension API
 
-Version 7.3.7 introduces extension API version 1. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes.
+Version 7.3.8 introduces extension API version 2. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes.
 
 Client-side extensions can read the normalized current-user location from `currentUser.geo_location`. The value is a location object when the current user has a valid saved location, otherwise it is `null`. Storage format and parsing remain internal to the base plugin.
 
 Server-side extensions should use `Locations::UserLocationStore` and `Locations::TopicLocationStore` rather than reading location custom fields directly. See [Location data ownership](docs/location-data-ownership.md) for the API and projection invariants.
+
+Extension API version 2 adds the `locations-users-map-controls` frontend outlet and `locations_users_map_query_options` server modifier. Together they let an add-on supply users-map controls and validated query options without replacing the base map component or controller.

--- a/assets/javascripts/discourse/components/locations-map.gjs
+++ b/assets/javascripts/discourse/components/locations-map.gjs
@@ -5,6 +5,8 @@ import { action, computed } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { findOrResetCachedTopicList } from "discourse/lib/cached-topic-list";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -15,6 +17,7 @@ import {
   generateMap,
   setupMap,
 } from "../lib/map-utilities";
+import { buildUsersMapRequestParams } from "../lib/users-map-extension";
 
 export default class LocationMapComponent extends Component {
   @service siteSettings;
@@ -31,6 +34,7 @@ export default class LocationMapComponent extends Component {
   @tracked topicList = {};
   @tracked user = {};
   @tracked userList = {};
+  @tracked usersMapRequestParams = {};
   @tracked mapObjs = {};
   @tracked markers = null;
   @tracked searchFilter = "";
@@ -96,6 +100,11 @@ export default class LocationMapComponent extends Component {
     // triggered in sidebar-container component in layouts plugin
   }
 
+  @action
+  setUsersMapRequestParams(requestParams = {}) {
+    this.usersMapRequestParams = { ...requestParams };
+  }
+
   async getLocationData() {
     const category = this.args.category;
 
@@ -123,7 +132,7 @@ export default class LocationMapComponent extends Component {
     }
 
     if (this.args.mapType === "userList") {
-      let params = { period: "location" };
+      const params = buildUsersMapRequestParams(this.usersMapRequestParams);
       this.userList = await this.store.find("directoryItem", params);
     }
   }
@@ -596,6 +605,7 @@ export default class LocationMapComponent extends Component {
     <div
       {{didInsert this.setup}}
       {{didUpdate this.setup @category}}
+      {{didUpdate this.setup this.usersMapRequestParams}}
       id="locations-map"
       class="locations-map {{if this.expanded 'expanded'}}"
     >
@@ -620,6 +630,15 @@ export default class LocationMapComponent extends Component {
       {{/if}}
       <div class="map-search">
         {{#if this.isMultipleLocations}}
+          {{#if this.isUserListType}}
+            <PluginOutlet
+              @name="locations-users-map-controls"
+              @outletArgs={{lazyHash
+                requestParams=this.usersMapRequestParams
+                setRequestParams=this.setUsersMapRequestParams
+              }}
+            />
+          {{/if}}
           <input
             type="text"
             value={{this.searchFilter}}

--- a/assets/javascripts/discourse/components/locations-map.gjs
+++ b/assets/javascripts/discourse/components/locations-map.gjs
@@ -17,7 +17,10 @@ import {
   generateMap,
   setupMap,
 } from "../lib/map-utilities";
-import { buildUsersMapRequestParams } from "../lib/users-map-extension";
+import {
+  buildUsersMapRequestParams,
+  normalizeUsersMapRequestParams,
+} from "../lib/users-map-extension";
 
 export default class LocationMapComponent extends Component {
   @service siteSettings;
@@ -102,7 +105,7 @@ export default class LocationMapComponent extends Component {
 
   @action
   setUsersMapRequestParams(requestParams = {}) {
-    this.usersMapRequestParams = { ...requestParams };
+    this.usersMapRequestParams = normalizeUsersMapRequestParams(requestParams);
   }
 
   async getLocationData() {

--- a/assets/javascripts/discourse/lib/users-map-extension.js
+++ b/assets/javascripts/discourse/lib/users-map-extension.js
@@ -1,3 +1,18 @@
-export function buildUsersMapRequestParams(extensionParams = {}) {
-  return { ...extensionParams, period: "location" };
+export function normalizeUsersMapRequestParams(extensionParams) {
+  if (
+    !extensionParams ||
+    typeof extensionParams !== "object" ||
+    Array.isArray(extensionParams)
+  ) {
+    return {};
+  }
+
+  return { ...extensionParams };
+}
+
+export function buildUsersMapRequestParams(extensionParams) {
+  return {
+    ...normalizeUsersMapRequestParams(extensionParams),
+    period: "location",
+  };
 }

--- a/assets/javascripts/discourse/lib/users-map-extension.js
+++ b/assets/javascripts/discourse/lib/users-map-extension.js
@@ -1,0 +1,3 @@
+export function buildUsersMapRequestParams(extensionParams = {}) {
+  return { ...extensionParams, period: "location" };
+}

--- a/docs/location-data-ownership.md
+++ b/docs/location-data-ownership.md
@@ -21,6 +21,20 @@ Use `Locations::UserLocationStore.fetch(user)` and `Locations::TopicLocationStor
 
 Client-side extensions receive the normalized current-user payload as `currentUser.geo_location` and do not need to know how it is stored.
 
+### Users-map extensions
+
+The `locations-users-map-controls` plugin outlet is rendered before the base users-map search control. Its `outletArgs` contain the current `requestParams` and a `setRequestParams` action. The action replaces the extension-owned parameters and reloads the existing map; the base plugin always supplies `period=location`, so extensions cannot redirect this fetch to another directory period.
+
+Server-side extensions can refine the matching relation and its limit with the `locations_users_map_query_options` modifier:
+
+```ruby
+register_modifier(:locations_users_map_query_options) do |options, guardian, params|
+  options.merge(query: options[:query].where(...), limit: 100)
+end
+```
+
+The modifier receives `{ query:, limit: }`, the request guardian, and a plain request-parameter hash. It must return the options hash. Extensions own validation and authorization for parameters they introduce. A limit must be a non-negative integer, or `nil` to leave the relation unlimited.
+
 ## Reconciliation
 
 Normal writes synchronize projections immediately. Administrators can repair historical or out-of-band drift across all sites with:

--- a/lib/users_map.rb
+++ b/lib/users_map.rb
@@ -32,7 +32,21 @@ module DirectoryItemsControllerExtension
               "users.last_seen_at DESC NULLS LAST, directory_items.id ASC"
             )
           )
-          .limit(limit)
+
+      query_options =
+        DiscoursePluginRegistry.apply_modifier(
+          :locations_users_map_query_options,
+          { query: result, limit: limit },
+          guardian,
+          params.to_unsafe_h
+        )
+      result = query_options.fetch(:query)
+      limit = query_options.fetch(:limit)
+      if !limit.nil? && (!limit.is_a?(Integer) || limit.negative?)
+        raise ArgumentError,
+              "locations_users_map_query_options limit must be a non-negative integer or nil"
+      end
+      result = result.limit(limit) if limit
 
       serializer_opts = {}
       serializer_opts[:attributes] = []

--- a/lib/users_map.rb
+++ b/lib/users_map.rb
@@ -43,7 +43,7 @@ module DirectoryItemsControllerExtension
       result = query_options.fetch(:query)
       limit = query_options.fetch(:limit)
       if !limit.nil? && (!limit.is_a?(Integer) || limit.negative?)
-        raise ArgumentError,
+        raise Discourse::InvalidParameters.new,
               "locations_users_map_query_options limit must be a non-negative integer or nil"
       end
       result = result.limit(limit) if limit

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.7
+# version: 7.3.8
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations
@@ -10,7 +10,7 @@ enabled_site_setting :location_enabled
 
 module ::Locations
   PLUGIN_NAME = "discourse-locations"
-  EXTENSION_API_VERSION = 1
+  EXTENSION_API_VERSION = 2
 end
 
 require_relative "lib/locations/engine"

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -229,6 +229,31 @@ RSpec.describe DirectoryItemsController do
         end
       end
 
+      it "returns a bad request when an extension supplies an invalid limit" do
+        SiteSetting.location_users_map = true
+        SiteSetting.enable_user_directory = true
+
+        plugin_instance = Plugin::Instance.new
+        modifier_block = proc { |options| options.merge(limit: "all") }
+        plugin_instance.register_modifier(
+          :locations_users_map_query_options,
+          &modifier_block
+        )
+
+        get "/directory_items.json", params: { period: "location" }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error_type"]).to eq("invalid_parameters")
+      ensure
+        if plugin_instance && modifier_block
+          DiscoursePluginRegistry.unregister_modifier(
+            plugin_instance,
+            :locations_users_map_query_options,
+            &modifier_block
+          )
+        end
+      end
+
       it "returns forbidden when the user directory is disabled" do
         SiteSetting.location_users_map = true
         SiteSetting.enable_user_directory = false

--- a/spec/requests/directory_items_controller_locations_extensions_spec.rb
+++ b/spec/requests/directory_items_controller_locations_extensions_spec.rb
@@ -157,6 +157,78 @@ RSpec.describe DirectoryItemsController do
         ).to eq([newest_user.id, *tied_user_ids])
       end
 
+      it "allows extensions to refine the users-map query and limit" do
+        newest_user = Fabricate(:user, last_seen_at: 1.hour.ago)
+        older_user = Fabricate(:user, last_seen_at: 1.day.ago)
+        excluded_user = Fabricate(:user, last_seen_at: 2.days.ago)
+
+        [newest_user, older_user, excluded_user].each do |map_user|
+          UserCustomField.create!(
+            user: map_user,
+            name: "geo_location",
+            value: { lat: "51.5074", lon: "-0.1278" }.to_json
+          )
+          Locations::UserLocationProcess.upsert(map_user.id)
+        end
+        DirectoryItem.refresh_period!(:daily, force: true)
+
+        SiteSetting.location_users_map = true
+        SiteSetting.location_users_map_limit = 3
+        SiteSetting.enable_user_directory = true
+
+        plugin_instance = Plugin::Instance.new
+        modifier_block =
+          proc do |options, guardian, request_params|
+            next options if guardian.user != user
+            next options if request_params["audience"] != "featured"
+
+            options.merge(
+              query:
+                options[:query].where(
+                  users: {
+                    id: [newest_user.id, older_user.id]
+                  }
+                ),
+              limit: request_params["user_limit"] == "all" ? nil : 1
+            )
+          end
+        plugin_instance.register_modifier(
+          :locations_users_map_query_options,
+          &modifier_block
+        )
+
+        get "/directory_items.json",
+            params: {
+              period: "location",
+              audience: "featured"
+            }
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["directory_items"].map { |item| item["id"] }
+        ).to eq([newest_user.id])
+
+        get "/directory_items.json",
+            params: {
+              period: "location",
+              audience: "featured",
+              user_limit: "all"
+            }
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["directory_items"].map { |item| item["id"] }
+        ).to eq([newest_user.id, older_user.id])
+      ensure
+        if plugin_instance && modifier_block
+          DiscoursePluginRegistry.unregister_modifier(
+            plugin_instance,
+            :locations_users_map_query_options,
+            &modifier_block
+          )
+        end
+      end
+
       it "returns forbidden when the user directory is disabled" do
         SiteSetting.location_users_map = true
         SiteSetting.enable_user_directory = false

--- a/test/javascripts/integration/components/locations-map-extension-test.gjs
+++ b/test/javascripts/integration/components/locations-map-extension-test.gjs
@@ -1,0 +1,54 @@
+import { fn, hash } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import LocationsMap from "discourse/plugins/discourse-locations/discourse/components/locations-map";
+
+module(
+  "Discourse Locations | Integration | locations map extension",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("an outlet control can replace users-map request parameters", async function (assert) {
+      const store = this.owner.lookup("service:store");
+      const findStub = sinon.stub(store, "find").resolves([]);
+
+      withPluginApi((api) => {
+        api.renderInOutlet(
+          "locations-users-map-controls",
+          <template>
+            <button
+              type="button"
+              class="test-set-users-map-params"
+              {{on
+                "click"
+                (fn @outletArgs.setRequestParams (hash group="team" limit=10))
+              }}
+            >Set filters</button>
+            <span class="test-users-map-group">
+              {{@outletArgs.requestParams.group}}
+            </span>
+          </template>
+        );
+      });
+
+      await render(<template><LocationsMap @mapType="userList" /></template>);
+
+      assert.deepEqual(findStub.firstCall.args, [
+        "directoryItem",
+        { period: "location" },
+      ]);
+
+      await click(".test-set-users-map-params");
+
+      assert.dom(".test-users-map-group").hasText("team");
+      assert.deepEqual(findStub.lastCall.args, [
+        "directoryItem",
+        { group: "team", limit: 10, period: "location" },
+      ]);
+    });
+  }
+);

--- a/test/javascripts/integration/components/locations-map-extension-test.gjs
+++ b/test/javascripts/integration/components/locations-map-extension-test.gjs
@@ -8,7 +8,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import LocationsMap from "discourse/plugins/discourse-locations/discourse/components/locations-map";
 
 module(
-  "Discourse Locations | Integration | locations map extension",
+  "Discourse Locations | Integration | Component | LocationsMap",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -28,6 +28,11 @@ module(
                 (fn @outletArgs.setRequestParams (hash group="team" limit=10))
               }}
             >Set filters</button>
+            <button
+              type="button"
+              class="test-clear-users-map-params"
+              {{on "click" (fn @outletArgs.setRequestParams null)}}
+            >Clear filters</button>
             <span class="test-users-map-group">
               {{@outletArgs.requestParams.group}}
             </span>
@@ -37,18 +42,33 @@ module(
 
       await render(<template><LocationsMap @mapType="userList" /></template>);
 
-      assert.deepEqual(findStub.firstCall.args, [
-        "directoryItem",
-        { period: "location" },
-      ]);
+      assert.deepEqual(
+        findStub.firstCall.args,
+        ["directoryItem", { period: "location" }],
+        "the base request has no extension parameters"
+      );
 
       await click(".test-set-users-map-params");
 
-      assert.dom(".test-users-map-group").hasText("team");
-      assert.deepEqual(findStub.lastCall.args, [
-        "directoryItem",
-        { group: "team", limit: 10, period: "location" },
-      ]);
+      assert
+        .dom(".test-users-map-group")
+        .hasText("team", "the outlet receives the current parameters");
+      assert.deepEqual(
+        findStub.lastCall.args,
+        ["directoryItem", { group: "team", limit: 10, period: "location" }],
+        "setting parameters reloads the user list"
+      );
+
+      await click(".test-clear-users-map-params");
+
+      assert
+        .dom(".test-users-map-group")
+        .hasNoText("invalid parameters are exposed as an empty object");
+      assert.deepEqual(
+        findStub.lastCall.args,
+        ["directoryItem", { period: "location" }],
+        "invalid parameters restore the base request"
+      );
     });
   }
 );

--- a/test/javascripts/unit/lib/users-map-extension-test.js
+++ b/test/javascripts/unit/lib/users-map-extension-test.js
@@ -1,15 +1,29 @@
 import { module, test } from "qunit";
 import { buildUsersMapRequestParams } from "discourse/plugins/discourse-locations/discourse/lib/users-map-extension";
 
-module("Discourse Locations | Unit | users map extension", function () {
+module("Discourse Locations | Unit | Lib | users-map-extension", function () {
   test("builds a location-directory request without allowing the period to be replaced", function (assert) {
     const extensionParams = { group: "team", period: "all", user_limit: 10 };
 
-    assert.deepEqual(buildUsersMapRequestParams(extensionParams), {
-      group: "team",
-      period: "location",
-      user_limit: 10,
-    });
+    assert.deepEqual(
+      buildUsersMapRequestParams(extensionParams),
+      {
+        group: "team",
+        period: "location",
+        user_limit: 10,
+      },
+      "extension parameters are retained but cannot replace the period"
+    );
     assert.strictEqual(extensionParams.period, "all", "does not mutate input");
+  });
+
+  test("ignores unsupported parameter values", function (assert) {
+    for (const extensionParams of [null, undefined, "group", 10, ["team"]]) {
+      assert.deepEqual(
+        buildUsersMapRequestParams(extensionParams),
+        { period: "location" },
+        `${String(extensionParams)} is treated as an empty parameter object`
+      );
+    }
   });
 });

--- a/test/javascripts/unit/lib/users-map-extension-test.js
+++ b/test/javascripts/unit/lib/users-map-extension-test.js
@@ -1,0 +1,15 @@
+import { module, test } from "qunit";
+import { buildUsersMapRequestParams } from "discourse/plugins/discourse-locations/discourse/lib/users-map-extension";
+
+module("Discourse Locations | Unit | users map extension", function () {
+  test("builds a location-directory request without allowing the period to be replaced", function (assert) {
+    const extensionParams = { group: "team", period: "all", user_limit: 10 };
+
+    assert.deepEqual(buildUsersMapRequestParams(extensionParams), {
+      group: "team",
+      period: "location",
+      user_limit: 10,
+    });
+    assert.strictEqual(extensionParams.period, "all", "does not mutate input");
+  });
+});


### PR DESCRIPTION
Previously, add-ons that extended users-map filtering had to replace base map and controller behavior, duplicating implementation.

This change adds versioned frontend and server extension seams, preserving base-only behavior while letting add-ons supply controls and safely refine the query and limit.