### PR TITLE
DEV: Keep extension API at version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The Locations Plugin allows you to associate geocoded locations with topics, and
 
 ### Extension API
 
-Version 7.3.8 introduces extension API version 2. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes.
+Version 7.3.7 introduced extension API version 1. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes. The API remains at version 1 while the modular extension contract is being completed and will be bumped once when that contract is ready for release.
 
 Client-side extensions can read the normalized current-user location from `currentUser.geo_location`. The value is a location object when the current user has a valid saved location, otherwise it is `null`. Storage format and parsing remain internal to the base plugin.
 
 Server-side extensions should use `Locations::UserLocationStore` and `Locations::TopicLocationStore` rather than reading location custom fields directly. See [Location data ownership](docs/location-data-ownership.md) for the API and projection invariants.
 
-Extension API version 2 adds the `locations-users-map-controls` frontend outlet and `locations_users_map_query_options` server modifier. Together they let an add-on supply users-map controls and validated query options without replacing the base map component or controller.
+Version 7.3.8 extends the in-development version 1 contract with the `locations-users-map-controls` frontend outlet and `locations_users_map_query_options` server modifier. Together they let an add-on supply users-map controls and validated query options without replacing the base map component or controller.

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.8
+# version: 7.3.9
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,7 @@ enabled_site_setting :location_enabled
 
 module ::Locations
   PLUGIN_NAME = "discourse-locations"
-  EXTENSION_API_VERSION = 2
+  EXTENSION_API_VERSION = 1
 end
 
 require_relative "lib/locations/engine"


### PR DESCRIPTION
Previously, the in-development extension API was incremented when the users-map seams landed even though the modular Pro contract is not yet released.

This change restores extension API version 1 while retaining the 7.3.8 plugin version and all merged seams, so the API can receive one coordinated bump after the Pro extension is complete.