### PR TITLE
DEV: Add a users-map surface extension seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Client-side extensions can read the normalized current-user location from `curre
 Server-side extensions should use `Locations::UserLocationStore` and `Locations::TopicLocationStore` rather than reading location custom fields directly. See [Location data ownership](docs/location-data-ownership.md) for the API and projection invariants.
 
 Version 7.3.8 extends the in-development version 1 contract with the `locations-users-map-controls` frontend outlet and `locations_users_map_query_options` server modifier. Together they let an add-on supply users-map controls and validated query options without replacing the base map component or controller.
+
+Version 7.3.10 adds the `locations-users-map-surface` outlet and shared active-surface state. An extension can render an alternative user-map surface from the base plugin's filtered marker data while leaving the default Leaflet surface unchanged when no alternative is active.

--- a/assets/javascripts/discourse/components/locations-map.gjs
+++ b/assets/javascripts/discourse/components/locations-map.gjs
@@ -38,6 +38,7 @@ export default class LocationMapComponent extends Component {
   @tracked user = {};
   @tracked userList = {};
   @tracked usersMapRequestParams = {};
+  @tracked usersMapActiveSurface = null;
   @tracked mapObjs = {};
   @tracked markers = null;
   @tracked searchFilter = "";
@@ -81,6 +82,10 @@ export default class LocationMapComponent extends Component {
     );
   }
 
+  get hasAlternativeUsersMapSurface() {
+    return this.isUserListType && this.usersMapActiveSurface !== null;
+  }
+
   @action
   changeFilterType(event) {
     this.searchFilterType = event.target.value;
@@ -90,6 +95,21 @@ export default class LocationMapComponent extends Component {
   filterLocations(event) {
     this.searchFilter = event.target.value;
 
+    this.refreshFilteredLocations();
+  }
+
+  @action
+  clearSearchFilter() {
+    if (!this.searchFilter) {
+      return;
+    }
+
+    this.searchFilter = "";
+
+    this.refreshFilteredLocations();
+  }
+
+  refreshFilteredLocations() {
     if (this.markers) {
       this.markers.clearLayers();
       this.markers = null;
@@ -106,6 +126,22 @@ export default class LocationMapComponent extends Component {
   @action
   setUsersMapRequestParams(requestParams = {}) {
     this.usersMapRequestParams = normalizeUsersMapRequestParams(requestParams);
+  }
+
+  @action
+  setUsersMapActiveSurface(surface = null) {
+    const nextSurface =
+      typeof surface === "string" && surface.trim() ? surface.trim() : null;
+
+    if (this.usersMapActiveSurface === nextSurface) {
+      return;
+    }
+
+    this.usersMapActiveSurface = nextSurface;
+
+    if (nextSurface === null && Object.keys(this.mapObjs).length) {
+      requestAnimationFrame(() => this.setupLocationMap());
+    }
   }
 
   async getLocationData() {
@@ -610,7 +646,9 @@ export default class LocationMapComponent extends Component {
       {{didUpdate this.setup @category}}
       {{didUpdate this.setup this.usersMapRequestParams}}
       id="locations-map"
-      class="locations-map {{if this.expanded 'expanded'}}"
+      class="locations-map
+        {{if this.expanded 'expanded'}}
+        {{if this.hasAlternativeUsersMapSurface 'has-alternative-surface'}}"
     >
       {{#if this.showExpand}}
         <button
@@ -637,7 +675,9 @@ export default class LocationMapComponent extends Component {
             <PluginOutlet
               @name="locations-users-map-controls"
               @outletArgs={{lazyHash
+                activeSurface=this.usersMapActiveSurface
                 requestParams=this.usersMapRequestParams
+                setActiveSurface=this.setUsersMapActiveSurface
                 setRequestParams=this.setUsersMapRequestParams
               }}
             />
@@ -716,6 +756,18 @@ export default class LocationMapComponent extends Component {
           </span>
         {{/if}}
       </div>
+      {{#if this.isUserListType}}
+        <PluginOutlet
+          @name="locations-users-map-surface"
+          @outletArgs={{lazyHash
+            activeSurface=this.usersMapActiveSurface
+            clearSearchFilter=this.clearSearchFilter
+            locations=this.filteredLocations
+            searchFilter=this.searchFilter
+            setActiveSurface=this.setUsersMapActiveSurface
+          }}
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/assets/stylesheets/common/locations.scss
+++ b/assets/stylesheets/common/locations.scss
@@ -104,6 +104,11 @@
   position: relative;
   border: 1px solid var(--primary-low);
 
+  &.has-alternative-surface > .leaflet-container,
+  &.has-alternative-surface > .btn-map {
+    display: none;
+  }
+
   .avatar-wrapper {
     position: absolute;
     top: 3px;

--- a/docs/location-data-ownership.md
+++ b/docs/location-data-ownership.md
@@ -25,6 +25,10 @@ Client-side extensions receive the normalized current-user payload as `currentUs
 
 The `locations-users-map-controls` plugin outlet is rendered before the base users-map search control. Its `outletArgs` contain the current `requestParams` and a `setRequestParams` action. The action replaces the extension-owned parameters and reloads the existing map; the base plugin always supplies `period=location`, so extensions cannot redirect this fetch to another directory period.
 
+The controls outlet also receives `activeSurface` and `setActiveSurface`. The default value is `null`, which keeps the base Leaflet surface and its controls visible. Passing a non-empty string selects an extension-owned surface; passing `null`, a blank string, or no value restores Leaflet.
+
+The `locations-users-map-surface` outlet is rendered only on the users map. It receives the same `activeSurface` and `setActiveSurface` values, plus `locations`, `searchFilter`, and `clearSearchFilter`. `locations` contains the base plugin's already-loaded and locally filtered marker payloads, not canonical custom-field data. Alternative surfaces should render only when their identifier matches `activeSurface`, and should restore the default surface if they cannot initialize.
+
 Server-side extensions can refine the matching relation and its limit with the `locations_users_map_query_options` modifier:
 
 ```ruby

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.9
+# version: 7.3.10
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/test/javascripts/integration/components/locations-map-extension-test.gjs
+++ b/test/javascripts/integration/components/locations-map-extension-test.gjs
@@ -1,74 +1,226 @@
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
-import { click, render } from "@ember/test-helpers";
+import { click, fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import LocationsMap from "discourse/plugins/discourse-locations/discourse/components/locations-map";
 
-module(
-  "Discourse Locations | Integration | Component | LocationsMap",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | LocationsMap", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("an outlet control can replace users-map request parameters", async function (assert) {
-      const store = this.owner.lookup("service:store");
-      const findStub = sinon.stub(store, "find").resolves([]);
+  test("an outlet control can replace users-map request parameters", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const findStub = sinon.stub(store, "find").resolves([]);
 
-      withPluginApi((api) => {
-        api.renderInOutlet(
-          "locations-users-map-controls",
-          <template>
-            <button
-              type="button"
-              class="test-set-users-map-params"
-              {{on
-                "click"
-                (fn @outletArgs.setRequestParams (hash group="team" limit=10))
-              }}
-            >Set filters</button>
-            <button
-              type="button"
-              class="test-clear-users-map-params"
-              {{on "click" (fn @outletArgs.setRequestParams null)}}
-            >Clear filters</button>
-            <span class="test-users-map-group">
-              {{@outletArgs.requestParams.group}}
-            </span>
-          </template>
-        );
-      });
-
-      await render(<template><LocationsMap @mapType="userList" /></template>);
-
-      assert.deepEqual(
-        findStub.firstCall.args,
-        ["directoryItem", { period: "location" }],
-        "the base request has no extension parameters"
-      );
-
-      await click(".test-set-users-map-params");
-
-      assert
-        .dom(".test-users-map-group")
-        .hasText("team", "the outlet receives the current parameters");
-      assert.deepEqual(
-        findStub.lastCall.args,
-        ["directoryItem", { group: "team", limit: 10, period: "location" }],
-        "setting parameters reloads the user list"
-      );
-
-      await click(".test-clear-users-map-params");
-
-      assert
-        .dom(".test-users-map-group")
-        .hasNoText("invalid parameters are exposed as an empty object");
-      assert.deepEqual(
-        findStub.lastCall.args,
-        ["directoryItem", { period: "location" }],
-        "invalid parameters restore the base request"
+    withPluginApi((api) => {
+      api.renderInOutlet(
+        "locations-users-map-controls",
+        <template>
+          <button
+            type="button"
+            class="test-set-users-map-params"
+            {{on
+              "click"
+              (fn @outletArgs.setRequestParams (hash group="team" limit=10))
+            }}
+          >Set filters</button>
+          <button
+            type="button"
+            class="test-clear-users-map-params"
+            {{on "click" (fn @outletArgs.setRequestParams null)}}
+          >Clear filters</button>
+          <span class="test-users-map-group">
+            {{@outletArgs.requestParams.group}}
+          </span>
+        </template>
       );
     });
-  }
-);
+
+    await render(<template><LocationsMap @mapType="userList" /></template>);
+
+    assert.deepEqual(
+      findStub.firstCall.args,
+      ["directoryItem", { period: "location" }],
+      "the base request has no extension parameters"
+    );
+
+    await click(".test-set-users-map-params");
+
+    assert
+      .dom(".test-users-map-group")
+      .hasText("team", "the controls outlet receives the current parameters");
+    assert.deepEqual(
+      findStub.lastCall.args,
+      ["directoryItem", { group: "team", limit: 10, period: "location" }],
+      "setting parameters reloads the user list"
+    );
+
+    await click(".test-clear-users-map-params");
+
+    assert
+      .dom(".test-users-map-group")
+      .hasNoText("invalid parameters are exposed as an empty object");
+    assert.deepEqual(
+      findStub.lastCall.args,
+      ["directoryItem", { period: "location" }],
+      "invalid parameters restore the base request"
+    );
+  });
+
+  test("surface outlets can activate and restore an alternative surface", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    sinon.stub(store, "find").resolves([]);
+
+    withPluginApi((api) => {
+      api.renderInOutlet(
+        "locations-users-map-controls",
+        <template>
+          <button
+            type="button"
+            class="test-set-users-map-surface"
+            {{on "click" (fn @outletArgs.setActiveSurface "globe")}}
+          >Set surface</button>
+          <span class="test-users-map-control-surface">
+            {{@outletArgs.activeSurface}}
+          </span>
+        </template>
+      );
+
+      api.renderInOutlet(
+        "locations-users-map-surface",
+        <template>
+          <button
+            type="button"
+            class="test-reset-users-map-surface"
+            {{on "click" (fn @outletArgs.setActiveSurface null)}}
+          >Reset surface</button>
+          <span class="test-users-map-surface">
+            {{@outletArgs.activeSurface}}
+          </span>
+        </template>
+      );
+    });
+
+    await render(<template><LocationsMap @mapType="userList" /></template>);
+
+    assert
+      .dom("#locations-map")
+      .doesNotHaveClass(
+        "has-alternative-surface",
+        "the base map is the default surface"
+      );
+
+    await click(".test-set-users-map-surface");
+
+    assert
+      .dom("#locations-map")
+      .hasClass(
+        "has-alternative-surface",
+        "selecting an extension surface hides the base map controls"
+      );
+    assert
+      .dom(".test-users-map-control-surface")
+      .hasText("globe", "the controls outlet receives the active surface");
+    assert
+      .dom(".test-users-map-surface")
+      .hasText("globe", "the surface outlet receives the active surface");
+
+    await click(".test-reset-users-map-surface");
+
+    assert
+      .dom("#locations-map")
+      .doesNotHaveClass(
+        "has-alternative-surface",
+        "the surface outlet can restore the base map"
+      );
+  });
+
+  test("the base map remains the default without a surface extension", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    sinon.stub(store, "find").resolves([]);
+
+    await render(<template><LocationsMap @mapType="userList" /></template>);
+
+    assert
+      .dom("#locations-map")
+      .doesNotHaveClass(
+        "has-alternative-surface",
+        "the default state does not activate an alternative surface"
+      );
+    assert
+      .dom("#locations-map > .leaflet-container")
+      .exists("the base Leaflet surface is still rendered");
+    assert
+      .dom("#locations-map > .btn-map")
+      .exists("the base map controls are still rendered");
+  });
+
+  test("a surface receives filtered locations and can clear search", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    sinon.stub(store, "find").resolves([
+      {
+        user: {
+          id: 1,
+          avatar_template: "/avatar/1/{size}.png",
+          geo_location: { lat: 51.5, lon: -0.1 },
+          name: "Alpha User",
+          username: "alpha",
+        },
+      },
+      {
+        user: {
+          id: 2,
+          avatar_template: "/avatar/2/{size}.png",
+          geo_location: { lat: 48.8, lon: 2.3 },
+          name: "Bravo User",
+          username: "bravo",
+        },
+      },
+    ]);
+
+    withPluginApi((api) => {
+      api.renderInOutlet(
+        "locations-users-map-surface",
+        <template>
+          <span class="test-surface-location-count">
+            {{@outletArgs.locations.length}}
+          </span>
+          <span class="test-surface-search-filter">
+            {{@outletArgs.searchFilter}}
+          </span>
+          <button
+            type="button"
+            class="test-clear-surface-search"
+            {{on "click" @outletArgs.clearSearchFilter}}
+          >Clear search</button>
+        </template>
+      );
+    });
+
+    await render(<template><LocationsMap @mapType="userList" /></template>);
+
+    assert
+      .dom(".test-surface-location-count")
+      .hasText("2", "the surface receives all loaded map locations");
+
+    await fillIn(".map-search > input[type='text']", "Alpha");
+
+    assert
+      .dom(".test-surface-location-count")
+      .hasText("1", "the surface receives the locally filtered locations");
+    assert
+      .dom(".test-surface-search-filter")
+      .hasText("Alpha", "the surface receives the current local search");
+
+    await click(".test-clear-surface-search");
+
+    assert
+      .dom(".map-search > input[type='text']")
+      .hasValue("", "the surface can clear the base search input");
+    assert
+      .dom(".test-surface-location-count")
+      .hasText("2", "clearing search restores all surface locations");
+  });
+});


### PR DESCRIPTION
Previously, extensions could add user-map controls and query parameters, but could not render an alternative map surface without replacing the base map component.

This change adds a minimal surface outlet and shared active-surface state, allowing an extension to reuse the base plugin's loaded and locally filtered marker data while leaving base-only Leaflet appearance and behavior unchanged.

## Extension surface contract

- Adds the `locations-users-map-surface` outlet only to the users map.
- Exposes `activeSurface` and `setActiveSurface` to both the controls and surface outlets.
- Exposes the base plugin's already-loaded and locally filtered `locations` to the surface outlet.
- Exposes `searchFilter` and `clearSearchFilter` so an alternative renderer can integrate with the base local search.
- Treats `null` as the default Leaflet surface and normalizes blank or non-string surface values back to that default.
- Allows an alternative surface to restore Leaflet if its own renderer cannot initialize.
- Hides the Leaflet container and base map buttons only while a non-empty alternative surface is active.

## Base-only impact

- No extension activates a surface by default.
- Existing Leaflet markup, controls, fetching, filtering, markers, and map setup remain in place.
- The new surface outlet renders no DOM when unused.
- The extension API remains at version 1 until the complete modular Pro contract is verified.
- Bumps the base plugin patch version from 7.3.9 to 7.3.10.

## Commits

- `b4d2c57` adds the surface state, outlet, visibility behavior, and focused tests.
- `ce5e4f6` documents the contract and bumps the patch version.

## Out of scope

- The Pro globe renderer and its assets.
- The map/globe toggle and URL state.
- The globe screen saver.
- The final coordinated extension API bump.

## Tests

- Base JavaScript suite: 33 passing, 2 intentionally skipped, 0 failures, and no deprecations.
- Covers extension request parameters independently from the new surface contract.
- Covers activating and restoring an alternative surface through both outlets.
- Covers filtered-location delivery and clearing the base local search.
- Covers the base-only default, including retained Leaflet markup and controls.
- Merged Pro filter component suite against this branch: 4 passing, 0 failures, and no deprecations.
- `bin/lint --fix` on every changed implementation and test file.
