### PR TITLE
FIX: Preload locations for bulk user cards

### DIFF
--- a/lib/locations/user_custom_field_preloader.rb
+++ b/lib/locations/user_custom_field_preloader.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ::Locations
+  module UserCustomFieldPreloader
+    def preload_custom_fields(objects, fields)
+      fields = fields.to_a
+      fields |= [UserLocationStore::FIELD_NAME] if SiteSetting.location_enabled
+
+      super(objects, fields)
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.10
+# version: 7.3.11
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations
@@ -42,6 +42,9 @@ after_initialize do
   require_relative "lib/users_map"
 
   reloadable_patch { TopicQuery.prepend(Locations::TopicQueryExtension) }
+  reloadable_patch do
+    User.singleton_class.prepend(Locations::UserCustomFieldPreloader)
+  end
 
   def Locations.parse_geo_location(val)
     Locations::Payload.parse(val)
@@ -113,10 +116,6 @@ after_initialize do
 
   if defined?(register_editable_user_custom_field)
     register_editable_user_custom_field("geo_location")
-  end
-
-  if User.respond_to? :preloaded_custom_fields
-    User.preloaded_custom_fields << "geo_location"
   end
 
   add_to_serializer(:user, :geo_location) do

--- a/spec/requests/users_controller_cards_spec.rb
+++ b/spec/requests/users_controller_cards_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe UsersController do
+  fab!(:user)
+  fab!(:user_without_location, :user)
+
+  describe "#cards" do
+    it "returns bespoke locations without exposing their canonical custom fields" do
+      SiteSetting.location_enabled = true
+      SiteSetting.public_user_custom_fields = "department"
+      user.user_stat.update!(post_count: 1)
+      user_without_location.user_stat.update!(post_count: 1)
+      location = {
+        lat: 51.5074,
+        lon: -0.1278,
+        city: "London",
+        countrycode: "gb"
+      }
+      Locations::UserLocationStore.set(user:, location:)
+      user.custom_fields["department"] = "Engineering"
+      user.save_custom_fields
+
+      get "/user-cards.json",
+          params: {
+            user_ids: "#{user.id},#{user_without_location.id}"
+          }
+
+      expect(response).to have_http_status(:ok)
+      cards =
+        response
+          .parsed_body
+          .fetch("users")
+          .index_by { |card| card.fetch("username") }
+      expect(cards.fetch(user.username).fetch("geo_location")).to eq(
+        location.stringify_keys
+      )
+      expect(cards.fetch(user_without_location.username)).not_to have_key(
+        "geo_location"
+      )
+      expect(cards.fetch(user.username).fetch("custom_fields")).to eq(
+        "department" => "Engineering"
+      )
+    end
+  end
+end

--- a/spec/requests/users_controller_cards_spec.rb
+++ b/spec/requests/users_controller_cards_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
+require "rails_helper"
 
 RSpec.describe UsersController do
   fab!(:user)
   fab!(:user_without_location, :user)
 
   describe "#cards" do
+    before { sign_in(user) }
+
     it "returns bespoke locations without exposing their canonical custom fields" do
       SiteSetting.location_enabled = true
       SiteSetting.public_user_custom_fields = "department"


### PR DESCRIPTION
Previously, removing `geo_location` from core's public custom-field allowlist left the bulk `/user-cards.json` path without the canonical field its Locations serializer reads, causing every eligible bulk-card request to return 500.

This change extends core's existing bulk user-custom-field preload query with the canonical location field while Locations is enabled, preserving the bespoke `geo_location` response without restoring or duplicating the raw public custom field.

Fixes #180.

### Root cause

- The user-card location serializer has existed since legacy commit `5c762cc` (April 2020).
- The bulk card endpoint only preloads fields returned by `User.allowed_user_custom_fields`.
- Commit `f3d4777` intentionally removed `geo_location` from `public_user_custom_fields` during the August 13 ownership/privacy refactor.
- That removal stopped the incidental preload but retained the bespoke serializer read, exposing core's guarded `HasCustomFields::NotPreloadedError`.

### Improvements

- Adds `geo_location` to calls through `User.preload_custom_fields` only while the Locations plugin is enabled.
- Reuses the existing bulk preload query, avoiding per-user/N+1 fallback reads.
- Keeps `geo_location` out of `User.allowed_user_custom_fields` and raw `custom_fields` responses.
- Preserves the normalized bespoke `geo_location` attribute for users who have a location.
- Leaves cards for users without locations unchanged.
- Replaces the ineffective legacy `User.preloaded_custom_fields` registration.
- Bumps the base plugin patch version from `7.3.10` to `7.3.11`.

### Tests

- Reproduced the reported endpoint failure against unpatched `main` with the exact `HasCustomFields::NotPreloadedError`.
- Added a request regression covering a mixed bulk response with located and unlocated users.
- Confirms explicitly public custom fields remain present while the canonical location JSON is not exposed through raw `custom_fields`.
- `bin/rspec plugins/discourse-locations/spec`: 65 examples, 0 failures.
- Focused lint for all changed files: passed.

### Out of scope

- Does not re-add `geo_location` to `public_user_custom_fields`.
- Does not change the location persistence or bespoke serialization contract.
- Does not change the extension API version.
