### PR TITLE
DEV: Document Locations base and Pro pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Discourse Locations adds structured and geocoded locations to topics and users, 
 
 ## Pro extension
 
-[Discourse Locations Pro Extension](https://github.com/merefield/discourse-locations-early-access) is an optional private extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above.
+[Discourse Locations Pro Extension](https://github.com/merefield/discourse-locations-pro-ext) is an optional private extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above.
 
 **[Sponsor on GitHub to get Locations Pro](https://github.com/sponsors/merefield)**
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,64 @@
-# Discourse Locations Plugin
+# Discourse Locations
 
-The Locations Plugin allows you to associate geocoded locations with topics, and list topics with locations on a map. Additionally it allows users to record their position (voluntarily) and this can show up on a map of Users in the Users directory.
+Discourse Locations adds structured and geocoded locations to topics and users, with map-based discovery throughout Discourse.
 
-:page_facing_up: [**Read the documentation**](https://coop.pavilion.tech/docs?category=90&solved=false)
+## Functionality
 
-:bug: **[Report a bug](https://coop.pavilion.tech/w/bug-report)**
+- Adds structured locations to topics, including optional or required geocoding.
+- Enables locations per category and supports category and site-wide topic map views.
+- Provides configurable map markers, clustering, labels, bounds, default centres, and tile providers.
+- Lets users save a voluntary profile location and optionally show it on posts, profiles, user cards, and the users directory map.
+- Supports configurable location formats, country flags, profile maps, and defaulting a new topic to the current user's location.
+- Includes local name and username search on the users map, deterministic recent-activity ordering, and privacy-aware location payloads.
+- Supports multiple geocoding providers while retaining textual locations when geocoding is not required.
 
-### Documentation Links
+## Pro extension
 
-- [Administration Settings](https://coop.pavilion.tech/docs?topic=1620)
-- [Locations in Topics](https://coop.pavilion.tech/docs?topic=1763)
-- [Locations in Categories](https://coop.pavilion.tech/docs?topic=1550)
+[Discourse Locations Pro Extension](https://github.com/merefield/discourse-locations-early-access) is an optional private extension available to GitHub Sponsors as a thank-you for supporting ongoing development.
 
-### Extension API
+**[Sponsor on GitHub to get Locations Pro](https://github.com/sponsors/merefield)**
 
-Version 7.3.7 introduced extension API version 1. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes. The API remains at version 1 while the modular extension contract is being completed and will be bumped once when that contract is ready for release.
+Once you have access, install the Pro extension alongside this base plugin to enable:
 
-Client-side extensions can read the normalized current-user location from `currentUser.geo_location`. The value is a location object when the current user has a valid saved location, otherwise it is `null`. Storage format and parsing remain internal to the base plugin.
+- Automated user-location estimation from IP data, with configurable precision and privacy safeguards.
+- Nearby-topic discovery based on the signed-in user's saved location.
+- Optional location-aware tools for `discourse-chatbot`.
+- Permission-aware group and result-limit filters on the users map.
+- An interactive WebGL globe alternative to the base Leaflet users map.
+- An optional idle globe screen saver that reuses the interactive renderer.
 
-Server-side extensions should use `Locations::UserLocationStore` and `Locations::TopicLocationStore` rather than reading location custom fields directly. See [Location data ownership](docs/location-data-ownership.md) for the API and projection invariants.
+The Pro extension has its own master setting and feature settings. Disabling or removing it leaves this base plugin's appearance and functionality unchanged.
 
-Version 7.3.8 extends the in-development version 1 contract with the `locations-users-map-controls` frontend outlet and `locations_users_map_query_options` server modifier. Together they let an add-on supply users-map controls and validated query options without replacing the base map component or controller.
+## Installation
 
-Version 7.3.10 adds the `locations-users-map-surface` outlet and shared active-surface state. An extension can render an alternative user-map surface from the base plugin's filtered marker data while leaving the default Leaflet surface unchanged when no alternative is active.
+Add the public plugin to your Discourse container's plugin clone section:
+
+```shell
+git clone https://github.com/merefield/discourse-locations.git
+```
+
+See [How to install plugins in Discourse](https://meta.discourse.org/t/install-plugins-in-discourse/19157) for the standard installation process.
+
+## Privacy and storage
+
+Complete editable locations are stored in model custom fields. The `locations_user` and `locations_topic` tables contain spatial projections used for map membership, proximity, distance, and ordering.
+
+Raw location custom fields are not globally public. The plugin exposes normalized data only through purpose-specific serializers and applies Discourse profile, group, and directory visibility rules to map results.
+
+See [Location data ownership](docs/location-data-ownership.md) for the storage contract and reconciliation task.
+
+## Extension API
+
+Extension API version 1 is the baseline contract used by the base and Pro pairing. Extensions can verify compatibility with `Locations::EXTENSION_API_VERSION` after the base plugin initializes.
+
+- Server-side extensions should use `Locations::UserLocationStore` and `Locations::TopicLocationStore` instead of reading location custom fields directly.
+- Client-side extensions can read the normalized current-user location from `currentUser.geo_location`.
+- Users-map extensions can use the `locations-users-map-controls` and `locations-users-map-surface` outlets and the `locations_users_map_query_options` server modifier.
+
+## Documentation and support
+
+- [Administration settings](https://coop.pavilion.tech/docs?topic=1620)
+- [Locations in topics](https://coop.pavilion.tech/docs?topic=1763)
+- [Locations in categories](https://coop.pavilion.tech/docs?topic=1550)
+- [Community discussion](https://meta.discourse.org/t/locations-plugin/69742?u=merefield)
+- [Report a bug](https://coop.pavilion.tech/w/bug-report)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Discourse Locations adds structured and geocoded locations to topics and users, 
 
 ## Pro extension
 
-[Discourse Locations Pro Extension](https://github.com/merefield/discourse-locations-early-access) is an optional private extension available to GitHub Sponsors as a thank-you for supporting ongoing development.
+[Discourse Locations Pro Extension](https://github.com/merefield/discourse-locations-early-access) is an optional private extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above.
 
 **[Sponsor on GitHub to get Locations Pro](https://github.com/sponsors/merefield)**
 

--- a/meta-topic.md
+++ b/meta-topic.md
@@ -47,7 +47,7 @@ Raw location custom fields are not made globally public. Topic, profile, card, p
 
 ### Pro extension
 
-[Discourse Locations Pro](https://github.com/merefield/discourse-locations-early-access) is an optional extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above. Eligible sponsors receive private-repository installation instructions.
+[Discourse Locations Pro](https://github.com/merefield/discourse-locations-pro-ext) is an optional extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above. Eligible sponsors receive private-repository installation instructions.
 
 The Pro extension adds automated IP lookup, Nearby topics, Chatbot tools, enhanced users-map filters, the interactive globe, and the globe screen saver. Each optional automation or integration remains disabled until configured, and the Pro master setting can disable all Pro behaviour without disabling the base plugin.
 

--- a/meta-topic.md
+++ b/meta-topic.md
@@ -47,7 +47,7 @@ Raw location custom fields are not made globally public. Topic, profile, card, p
 
 ### Pro extension
 
-[Discourse Locations Pro](https://github.com/merefield/discourse-locations-early-access) is an optional extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Sponsors with access receive private-repository installation instructions.
+[Discourse Locations Pro](https://github.com/merefield/discourse-locations-early-access) is an optional extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Individual and independent-community sponsors receive access from the **$7/month Bronze tier**; businesses and institutions must sponsor at the **$40/month Silver tier** or above. Eligible sponsors receive private-repository installation instructions.
 
 The Pro extension adds automated IP lookup, Nearby topics, Chatbot tools, enhanced users-map filters, the interactive globe, and the globe screen saver. Each optional automation or integration remains disabled until configured, and the Pro master setting can disable all Pro behaviour without disabling the base plugin.
 

--- a/meta-topic.md
+++ b/meta-topic.md
@@ -1,0 +1,54 @@
+| | | |
+| - | - | - |
+| :information_source: | **Summary** | A Discourse plugin that adds structured and geocoded topic and user locations with map-based discovery |
+| :hammer_and_wrench: | **Repository Link** | <https://github.com/merefield/discourse-locations> |
+| :open_book: | **Install Guide** | [How to install plugins in Discourse](https://meta.discourse.org/t/install-plugins-in-discourse/19157) |
+| :heart: | **Sponsorship** | Please consider becoming an ongoing [sponsor of my open source work](https://github.com/sponsors/merefield) at a level that suits your or your organisation's resources and needs to ensure this plugin gets the maintenance it deserves and continues to work for your site in the future. |
+
+Enjoying this plugin? Please :star: it on [GitHub](https://github.com/merefield/discourse-locations)! :pray:
+
+### Features
+
+Discourse Locations provides the complete location-storage, geocoding, and map foundation. The optional Pro extension adds advanced discovery, automation, and users-map presentation while requiring this base plugin.
+
+| Feature | Base plugin | Pro extension |
+| --- | --- | --- |
+| Structured topic locations and configurable input fields | :white_check_mark: | — |
+| Optional or required geocoding with multiple providers | :white_check_mark: | — |
+| Category and site-wide topic map views | :white_check_mark: | — |
+| User locations on posts, profiles, cards, and the directory map | :white_check_mark: | — |
+| Leaflet users map with local name and username search | :white_check_mark: | — |
+| Configurable location labels, flags, map markers, clustering, and tiles | :white_check_mark: | — |
+| Default a new topic to the current user's location | :white_check_mark: | — |
+| Automated IP-based user-location estimation | — | :white_check_mark: **Exclusive** |
+| Nearby-topic discovery based on the current user's location | — | :white_check_mark: **Exclusive** |
+| Optional location-aware `discourse-chatbot` tools | — | :white_check_mark: **Exclusive** |
+| Permission-aware group and result-limit users-map filters | — | :white_check_mark: **Exclusive** |
+| Interactive WebGL users-map globe | — | :white_check_mark: **Exclusive** |
+| Idle globe screen saver | — | :white_check_mark: **Exclusive** |
+
+Installing Pro adds its exclusive features to the base functionality; it does not replace the base plugin.
+
+### Configuration
+
+The base plugin's settings use the `location_` prefix and control topic locations, geocoding, map display, user locations, and the standard users map.
+
+Useful documentation:
+
+* [Administration settings](https://coop.pavilion.tech/docs?topic=1620)
+* [Locations in topics](https://coop.pavilion.tech/docs?topic=1763)
+* [Locations in categories](https://coop.pavilion.tech/docs?topic=1550)
+
+### Privacy and storage
+
+Users choose whether to save a profile location. Complete editable topic and user locations remain in base-owned custom fields, while plugin-owned projection tables support spatial queries and map ordering.
+
+Raw location custom fields are not made globally public. Topic, profile, card, post, and directory responses expose only the location data required by that surface and respect Discourse's profile and group visibility rules.
+
+### Pro extension
+
+[Discourse Locations Pro](https://github.com/merefield/discourse-locations-early-access) is an optional extension available to GitHub Sponsors as a thank-you for supporting ongoing development. Sponsors with access receive private-repository installation instructions.
+
+The Pro extension adds automated IP lookup, Nearby topics, Chatbot tools, enhanced users-map filters, the interactive globe, and the globe screen saver. Each optional automation or integration remains disabled until configured, and the Pro master setting can disable all Pro behaviour without disabling the base plugin.
+
+**[Sponsor on GitHub to get Locations Pro](https://github.com/sponsors/merefield)**

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.11
+# version: 7.3.12
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations


### PR DESCRIPTION
Previously, the base repository did not clearly describe the completed base/Pro pairing or provide a maintainable Meta topic source.

This change rewrites the README and adds `meta-topic.md` with installation, ownership, privacy, sponsor-tier eligibility, the API version 1 baseline, and a base-versus-Pro feature catalogue, links the final `discourse-locations-pro-ext` repository, and advances the plugin patch version to 7.3.12 as required by repository metadata checks.

Keep this PR in draft and do not merge it independently: first verify the exact base and Pro branches together on production and verify a clean clone from the final Pro URL, then merge both release PRs, update the existing Meta topic, and notify existing sponsors in the same release window.