### PR TITLE
FIX: Contain post location labels on narrow screens

### DIFF
--- a/assets/stylesheets/common/locations-user.scss
+++ b/assets/stylesheets/common/locations-user.scss
@@ -144,7 +144,9 @@
     align-items: center;
 
     .user-location {
+      min-width: 0;
       padding: 0 11px 0 11px;
+      overflow-wrap: anywhere;
     }
 
     .location-flag {

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.12
+# version: 7.3.13
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations

--- a/spec/system/page_objects/post_location.rb
+++ b/spec/system/page_objects/post_location.rb
@@ -9,17 +9,21 @@ module PageObjects
 
       def bounds
         {
-          avatar: find("#{@post_selector} .topic-avatar").native.bounding_box,
-          summary:
-            find("#{@post_selector} .location-summary").native.bounding_box,
-          location:
-            find("#{@post_selector} .user-location").native.bounding_box,
-          flag: find("#{@post_selector} .location-flag").native.bounding_box
+          avatar: element_bounds(".topic-avatar"),
+          summary: element_bounds(".location-summary"),
+          location: element_bounds(".user-location"),
+          flag: element_bounds(".location-flag")
         }
       end
 
       def has_location?(text)
         has_css?("#{@post_selector} .user-location", text:)
+      end
+
+      private
+
+      def element_bounds(selector)
+        find("#{@post_selector} #{selector}").rect.transform_keys(&:to_sym)
       end
     end
   end

--- a/spec/system/page_objects/post_location.rb
+++ b/spec/system/page_objects/post_location.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class PostLocation < PageObjects::Components::Base
+      def initialize(post)
+        @post_selector = ".topic-post[data-post-number='#{post.post_number}']"
+      end
+
+      def bounds
+        {
+          avatar: find("#{@post_selector} .topic-avatar").native.bounding_box,
+          summary:
+            find("#{@post_selector} .location-summary").native.bounding_box,
+          location:
+            find("#{@post_selector} .user-location").native.bounding_box,
+          flag: find("#{@post_selector} .location-flag").native.bounding_box
+        }
+      end
+
+      def has_location?(text)
+        has_css?("#{@post_selector} .user-location", text:)
+      end
+    end
+  end
+end

--- a/spec/system/user_location_spec.rb
+++ b/spec/system/user_location_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe "User can manage their location" do
   fab!(:user)
   fab!(:topic) { Fabricate(:topic, user: user) }
@@ -91,4 +90,3 @@ RSpec.describe "User can manage their location" do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/system/user_location_spec.rb
+++ b/spec/system/user_location_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe "User can manage their location" do
   fab!(:user)
   fab!(:topic) { Fabricate(:topic, user: user) }
@@ -12,6 +13,7 @@ RSpec.describe "User can manage their location" do
   let(:location_selector) do
     PageObjects::Components::LocationSelector.new ".location-selector-wrapper"
   end
+  let(:post_location) { PageObjects::Components::PostLocation.new(post) }
   fab!(:address_string) do
     "Hope Street, Canning / Georgian Quarter, Toxteth, Liverpool, Liverpool City Region, England, L1 9BW, United Kingdom"
   end
@@ -72,5 +74,21 @@ RSpec.describe "User can manage their location" do
       page.refresh
       expect(location_selector).to have_no_selected_locations
     end
+
+    it "keeps the post location readable beside the avatar on narrow screens" do
+      SiteSetting.location_user_country_flag = true
+      SiteSetting.location_user_post_format = "countrycode"
+      page.current_window.resize_to(160, 800)
+
+      topic_page.visit_topic(topic)
+      expect(post_location).to have_location("United Kingdom")
+
+      bounds = post_location.bounds
+      expect(bounds[:location]["x"]).to be >=
+        bounds[:avatar]["x"] + bounds[:avatar]["width"]
+      expect(bounds[:flag]["x"] + bounds[:flag]["width"]).to be <=
+        bounds[:summary]["x"] + bounds[:summary]["width"]
+    end
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/system/user_location_spec.rb
+++ b/spec/system/user_location_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe "User can manage their location" do
       expect(post_location).to have_location("United Kingdom")
 
       bounds = post_location.bounds
-      expect(bounds[:location]["x"]).to be >=
-        bounds[:avatar]["x"] + bounds[:avatar]["width"]
-      expect(bounds[:flag]["x"] + bounds[:flag]["width"]).to be <=
-        bounds[:summary]["x"] + bounds[:summary]["width"]
+      expect(bounds[:location][:x]).to be >=
+        bounds[:avatar][:x] + bounds[:avatar][:width]
+      expect(bounds[:flag][:x] + bounds[:flag][:width]).to be <=
+        bounds[:summary][:x] + bounds[:summary][:width]
     end
   end
 end


### PR DESCRIPTION
Previously, long post location labels could overflow their flex row and collide with adjacent post metadata on very narrow screens.

This change allows the label to shrink and wrap within the available space, with system coverage for avatar and flag containment.