### PR TITLE
FIX: Remove obsolete PM location offset

### DIFF
--- a/assets/stylesheets/mobile/locations.scss
+++ b/assets/stylesheets/mobile/locations.scss
@@ -59,10 +59,6 @@
   }
 }
 
-.private_message .topic-body .user-location {
-  margin-left: 44px;
-}
-
 .d-modal__body .locations-map {
   height: 350px;
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-locations
 # about: Tools for handling locations in Discourse
-# version: 7.3.13
+# version: 7.3.14
 # authors: Robert Barrow, Angus McLeod
 # contact_emails: merefield@gmail.com
 # url: https://github.com/merefield/discourse-locations


### PR DESCRIPTION
Previously, narrow PM post metadata applied a legacy 44px left margin to user location labels, which could misalign long locations against the current core PM layout.

This change removes the obsolete PM-specific offset so location labels use the shared post metadata alignment.